### PR TITLE
Updated live-reload tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 test/tests/node_modules/
+test/tests/live/node_modules/
 doc/
 .idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,8 +21,26 @@ module.exports = function(grunt){
 					dest: "test/tests/",
 					filter: "isFile"
 				}]
-			}
+			},
+			toLive: {
+				files: [{
+					expand: true,
+					src:["node_modules/can/**"],
+					dest: "test/tests/live/",
+					filter: "isFile"
+				}, {
+					expand: true,
+					src:["node_modules/jquery/**"],
+					dest: "test/tests/live/",
+					filter: "isFile"
 
+				}, {
+					expand: true,
+					src:["node_modules/done-autorender/**"],
+					dest: "test/tests/live/",
+					filter: "isFile"
+				}]
+			}
 		}
 	});
 

--- a/bin/can-serve
+++ b/bin/can-serve
@@ -14,11 +14,15 @@ program.version(pkg.version)
   .option('-r, --proxy <url>', 'A URL to an API that should be proxied')
   .option('-t, --proxy-to <path>', 'The path to proxy to (default: /api)')
   .option('-l, --no-live-reload', 'Turn off live-reload')
+  .option('--main <main>', 'Specify your main module')
   .parse(process.argv);
 
 var options = {
-  path: process.cwd(),
-  liveReload: program.liveReload
+	path: process.cwd(),
+	system: {
+		liveReload: program.liveReload,
+		main: program.main
+	}
 };
 
 if(program.proxy) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -27,10 +27,10 @@ module.exports = function (options) {
 		app.use(apiPath, proxy(options.proxy));
 	}
 
-	var system = {
-		liveReload: options.liveReload,
-		liveReloadHost: os.hostname()
-	};
+	var system = options.system || {};
+	system.liveReloadHost = os.hostname();
+
+	// Old API
 	if(options.main) {
 		system.main = options.main;
 	}

--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -1,7 +1,9 @@
 var WebSocketClient = require('websocket').client;
+var EventEmitter = require("events");
 
 var MyWebSocket = global.WebSocket = function(address){
 	this.address = address;
+	this.emitter = new EventEmitter();
 
 	// Create the connection here
 	this.client = new WebSocketClient();
@@ -12,11 +14,13 @@ var MyWebSocket = global.WebSocket = function(address){
 
 		ws.connection.on("message", function(data){
 			var msg = data.utf8Data;
+			var msgObject = {
+				data: msg
+			};
 			if(ws.onmessage) {
-				ws.onmessage({
-					data: msg
-				});
+				ws.onmessage(msgObject);
 			}
+			ws.emitter.emit("message", msgObject);
 		});
 
 		if(ws.onopen) {
@@ -24,6 +28,13 @@ var MyWebSocket = global.WebSocket = function(address){
 		}
 	});
 	this.client.connect(this.address);
+};
+
+MyWebSocket.prototype.addEventListener = function(event, cb){
+	this.emitter.on(event, cb);
+};
+MyWebSocket.prototype.removeEventListener = function(event, cb){
+	this.emitter.removeListener(event, cb);
 };
 
 MyWebSocket.prototype.send = function(msg){

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
   },
   "scripts": {
     "jshint": "jshint lib/.  test/*.js --config",
-    "test:only": "grunt && npm run test:node && npm run test:browser",
+    "test:only": "grunt && npm run test:node && npm run test:browser && npm run test:live-reload",
     "test": "npm run jshint && npm run test:only",
     "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
+	"test:live-reload": "node test/run_live_tests",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
@@ -44,7 +45,8 @@
     "mocha": "^2.2.4",
     "request": "^2.61.0",
     "steal-qunit": "0.0.4",
-    "testee": "^0.2.0"
+    "testee": "^0.2.0",
+	"live-reload-testing": "^2.1.0"
   },
   "dependencies": {
     "can": "^2.3.0-pre.1",
@@ -60,7 +62,8 @@
   "system": {
     "npmDependencies": [
       "can",
-      "steal-qunit"
+      "steal-qunit",
+	  "live-reload-testing"
     ]
   }
 }

--- a/test/live.html
+++ b/test/live.html
@@ -1,0 +1,3 @@
+<title>can-serve live-reload</title>
+<script src="../node_modules/steal/steal.js" main="test/live_test"></script>
+<div id="qunit-fixture"></div>

--- a/test/live_test.js
+++ b/test/live_test.js
@@ -1,0 +1,79 @@
+require("../lib/server/websocket");
+var Steal = require("steal");
+var http = require("http");
+var assert = require("assert");
+
+function req(){
+	return new Promise(function(resolve, reject){
+		var opts = { port: 8787 };
+		var req = http.request(opts, function(res) {
+			var body = "";
+			res.setEncoding('utf8');
+			res.on('data', function (chunk) {
+				body += chunk;
+			});
+			res.on('end', function() {
+				resolve(body);
+			});
+		});
+		req.on("error", function(err){
+			reject(err);
+		});
+		req.end();
+	});
+}
+
+function wait(ms) {
+	return new Promise(function(resolve){
+		setTimeout(resolve, ms);
+	});
+}
+
+describe("can-ssr live-reload", function(){
+	before(function(done){
+		var self = this;
+
+		var steal = Steal.clone();
+		var loader = global.System = steal.System;
+
+		loader.config({
+			config: __dirname + "/../package.json!npm",
+			main: "live-reload-testing",
+			liveReloadHost: "localhost"
+		});
+
+		steal.startup().then(function(args){
+			self.liveReloadTest = args[0];
+			done();
+		}, done);
+	});
+
+	afterEach(function(done){
+		this.liveReloadTest.reset().then(function(){
+			done();
+		});
+	});
+
+	it("initial html is correct", function(done){
+		req().then(function(html){
+			assert(/hello world/.test(html), "The initial html is correct.");
+		}).then(done, done);
+	});
+
+	it("changes when the html changes", function(done){
+		var content = "<html><head><title>live-reload test</title></head>" +
+			"<body><can-import from='state' as='viewModel' />" +
+			"<span>hello live</span>";
+		var address = "index.stache";
+
+		var liveReloadTest = this.liveReloadTest;
+
+		liveReloadTest.put(address, content).then(function(){
+			return wait(200);
+		}).then(function(){
+			return req();
+		}).then(function(html){
+			assert(/hello live/.test(html), "html updated after a live reload");
+		}).then(done, done);
+	});
+});

--- a/test/run_live_tests.js
+++ b/test/run_live_tests.js
@@ -1,0 +1,20 @@
+var spawn = require("child_process").spawn;
+
+// Node 0.10.0 doesn't support Symbol which the websocket server needs,
+// so we won't try to run the tests on it.
+if(typeof Symbol === "undefined") {
+	process.exit(0);
+}
+
+var popts = { stdio: "inherit" };
+var lchild = spawn("node", ["test/tests/live/live_server"], popts);
+
+setTimeout(function(){
+	var child = spawn("mocha", ["test/live_test"], popts);
+
+	child.on("exit", function(code){
+		lchild.kill();
+		process.exit(code);
+	});
+
+}, 3000);

--- a/test/tests/live/index.stache
+++ b/test/tests/live/index.stache
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<title>live-reload test</title>
+	</head>
+	<body>
+		<can-import from="state" as="viewModel" />
+
+		<span>hello world</span>
+	</body>
+</html>

--- a/test/tests/live/live_server.js
+++ b/test/tests/live/live_server.js
@@ -1,0 +1,18 @@
+var path = require("path");
+var spawn = require("child_process").spawn;
+
+var popts = { stdio: "inherit" };
+
+process.chdir("test/tests/live");
+
+var canServe = path.resolve(__dirname + "/../../../bin/can-serve");
+var lrTest = path.resolve(__dirname + "/../../../node_modules/.bin/live-reload-test");
+
+var cchild = spawn(canServe, ["--main", "index.stache!done-autorender", "--port",
+	"8787"], popts);
+var lchild = spawn(lrTest, ["--main", "index.stache!done-autorender"], popts);
+
+process.on("exit", function(){
+	cchild.kill();
+	lchild.kill();
+});

--- a/test/tests/live/package.json
+++ b/test/tests/live/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "live-project",
+	"main": "index.stache!done-autorender",
+	"version": "1.0.0",
+	"dependencies": {
+		"can": "2.3.0-pre.1",
+		"done-autorender": "0.0.7"
+	},
+	"system": {
+		"paths": { "./app-map": "../../../app-map.js" },
+		"configDependencies": [
+			"live-reload"
+		]
+	}
+}

--- a/test/tests/live/state.js
+++ b/test/tests/live/state.js
@@ -1,0 +1,10 @@
+var AppMap = require("app-map");
+
+var route = require("can/route/route");
+require("can/route/pushstate/pushstate");
+
+module.exports = AppMap.extend({
+	env: function(){
+		return System.FOO;
+	}
+});


### PR DESCRIPTION
This refactors how the live-reload tests work making them a bit better.
The way it works is we start a script that launches a `live-reload-test`
server and a `can-serve` server on a project. The test uses Steal to
load `live-reload-testing` with the WebSocket polyfill so the module can
be used the same way as in the client. Then we just modify the project
and curl the result to see if it changed correctly.
