### PR TITLE
Verify that relative paths work with can-import bundles

### DIFF
--- a/test/can-serve_test.js
+++ b/test/can-serve_test.js
@@ -3,7 +3,7 @@ var path = require("path");
 var spawn = require("child_process").spawn;
 
 describe("can-serve cli tests", function(){
-	this.timeout(30000);
+	this.timeout(60000);
 
 	var isWin = /^win/.test(process.platform);
 	var platformExt = function(p) {

--- a/test/test.js
+++ b/test/test.js
@@ -44,7 +44,7 @@ describe("rendering an app", function(){
 			assert.ok(!hasError.test(result.html), 'does not print an error message');
 			assert.equal(result.state.attr('statusCode'), 200);
 			assert.equal(found["progressive/main.css!$css"], true, "Found the main css");
-			assert.equal(found["progressive/orders/orders.css!$css"], true, "Found the orders bundle css");
+			assert.equal(found["basics-can@0.0.1#progressive/orders/orders.css!$css"], true, "Found the orders bundle css");
 			assert.equal(found["@inline-cache"], true, "The inline-cache was registered");
 		}).then(done);
 	});
@@ -67,8 +67,7 @@ describe("rendering an app", function(){
 
 			return render("/");
 		}).then(function(result){
-			checkCount(result, 1, "There should only be 1 style for the root page");
-
+			checkCount(result, 2, "There should be 2 styles for the home page");
 			done();
 		});
 	});
@@ -86,12 +85,15 @@ describe("rendering an app", function(){
 	});
 
 	it("renders html5 conditional comment", function(done){
-		this.render("/orders").then(function(result){
+		var render = this.render;
+		render("/").then(function(){
+			return render("/orders");
+		}).then(function(result){
 			assert.ok(/<!--\[if lt IE 9\]>/.test(result.html), "beginning comment added");
 			assert.ok(/\/scripts\/html5shiv\.min\.js/.test(result.html), "contains the correct path to html5shiv");
 			assert.ok(/<!\[endif\]-->/.test(result.html), "ending comment added");
 
-			assert.ok(/html5\.elements = "can-import order-history"/.test(result.html), "Custom tags added to shim the document");
+			assert.ok(/html5\.elements = "can-import home-page order-history"/.test(result.html), "Custom tags added to shim the document");
 
 		}).then(done);
 	});

--- a/test/tests/progressive/home/home.css
+++ b/test/tests/progressive/home/home.css
@@ -1,0 +1,3 @@
+home-page {
+	color: green;
+}

--- a/test/tests/progressive/home/home.js
+++ b/test/tests/progressive/home/home.js
@@ -1,0 +1,8 @@
+require("./home.css!");
+var can = require("can");
+
+can.Component.extend({
+	tag: 'home-page',
+	template: require("./home.stache!"),
+	viewModel: {}
+});

--- a/test/tests/progressive/home/home.stache
+++ b/test/tests/progressive/home/home.stache
@@ -1,0 +1,1 @@
+<div id="home">You are {{page}}</div>

--- a/test/tests/progressive/index.stache
+++ b/test/tests/progressive/index.stache
@@ -11,11 +11,15 @@
 		<can-import from="progressive/main.css!"/>
 
 		{{#eq page "home"}}
-			<div id="home">You are {{page}}</div>
+			<can-import from="./progressive/home/">
+				{{#eq state "resolved"}}
+					<home-page></home-page>
+				{{/eq}}
+			</can-import>
 		{{/eq}}
 
 		{{#eq page "orders"}}
-			<can-import from="progressive/orders/">
+			<can-import from="./progressive/orders/">
 				{{#eq state "resolved"}}
 					<order-history></order-history>
 				{{/eq}}


### PR DESCRIPTION
This verifies that can-import supports relative paths when the
can-import is for a bundle. Also verifies that when using it this way we
get only the correct css needed for the request.
