### PR TITLE
Remove __addSerializerAndParser call

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,11 @@ module.exports = function(grunt){
 					filter: "isFile"
 				}, {
 					expand: true,
+					src:["node_modules/can-zone/**"],
+					dest: "test/tests/",
+					filter: "isFile"
+				}, {
+					expand: true,
 					src:["node_modules/can-wait/**"],
 					dest: "test/tests/node_modules/done-autorender/",
 					filter: "isFile"

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,12 +86,6 @@ module.exports = function(cfg, options){
 
 			addCookies(doc, request);
 
-			// doc.__addSerializerAndParser is not available in CanJS older than 2.3.11
-			if (typeof doc.__addSerializerAndParser === "function") {
-				doc.__addSerializerAndParser(document.__serializer,
-											document.__parser);
-			}
-
 			var serializeFromBody = !!(main.renderAsync ||
 									   main.serializeFromBody);
 			if(!serializeFromBody) {


### PR DESCRIPTION
This was needed in can < 2.3.20 but has now been fixed. Closes #128