### PR TITLE
Allow asynchronous statusCodes

### DIFF
--- a/lib/zones/response.js
+++ b/lib/zones/response.js
@@ -11,9 +11,8 @@ module.exports = function(stream){
 			},
 
 			ended: function(){
-				var state = data.state;
-				stream.emit("state", state);
-				var statusCode = state && state.attr("statusCode") || 200;
+				stream.emit("state", data.state);
+				var statusCode = data.statusCode || 200;
 				var responses = stream.dests;
 
 				responses.forEach(function(response){

--- a/lib/zones/route_data.js
+++ b/lib/zones/route_data.js
@@ -3,7 +3,7 @@ var intercept = require("../intercept").once;
 // Override can.route.data on every Task execution
 module.exports = function(data){
 
-	var oldData, viewModel;
+	var oldData, viewModel, noop = function(){};
 
 	function hasCanRoute(){
 		return typeof can !== "undefined" && !!can.route;
@@ -17,6 +17,7 @@ module.exports = function(data){
 				oldData = can.route.data;
 				intercept(can.route, "data", function(data){
 					viewModel = data;
+					viewModel.bind("statusCode", noop);
 				});
 			}
 		},
@@ -32,7 +33,9 @@ module.exports = function(data){
 			}
 		},
 		ended: function(){
+			data.statusCode = viewModel.attr("statusCode");
 			data.state = viewModel;
+			viewModel.unbind("statusCode", noop);
 		}
 	};
 };

--- a/lib/zones/route_data.js
+++ b/lib/zones/route_data.js
@@ -33,9 +33,11 @@ module.exports = function(data){
 			}
 		},
 		ended: function(){
-			data.statusCode = viewModel.attr("statusCode");
-			data.state = viewModel;
-			viewModel.unbind("statusCode", noop);
+			if(viewModel) {
+				data.statusCode = viewModel.attr("statusCode");
+				data.state = viewModel;
+				viewModel.unbind("statusCode", noop);
+			}
 		}
 	};
 };

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -48,4 +48,14 @@ describe("async rendering", function(){
 			done();
 		}));
 	});
+
+	it("sets a 404 status for bad routes", function(done){
+		var response = through(function(){
+			var statusCode = response.statusCode;
+			assert.equal(statusCode, 404, "Got a 404");
+			done();
+		});
+
+		this.render("/fake").pipe(response);
+	});
 });

--- a/test/tests/async/appstate.js
+++ b/test/tests/async/appstate.js
@@ -17,6 +17,16 @@ module.exports = AppMap.extend({
 		},
 		message: {
 			type: "string"
+		},
+		statusCode: {
+			get: function(val, setVal){
+				if(!setVal) return 200;
+				var page = this.attr("page");
+				setTimeout(function(){
+					var status = page === "fake" ? 404 : 200;
+					setVal(status);
+				}, 50);
+			}
 		}
 	}
 });


### PR DESCRIPTION
This makes it so that asynchronous statusCodes are possible. When
`can.route.data` is set we bind to its `statusCode` property and then
unbind after the zone has completed.

Example code:

```js
statusCode: {
	get: function(val, setVal){
		if(!setVal) return 200;
		var page = this.attr("page");
		setTimeout(function(){
			var status = page === "fake" ? 404 : 200;
			setVal(status);
		}, 50);
	}
}
```