### PR TITLE
Handle when an XHR errors

### DIFF
--- a/lib/zones/xhr.js
+++ b/lib/zones/xhr.js
@@ -1,6 +1,8 @@
 var Zone = require("can-zone");
 var xhrZone = require("can-zone/xhr");
 
+var noop = function(){};
+
 module.exports = function(data){
 
 	var oldSend;
@@ -9,10 +11,13 @@ module.exports = function(data){
 		var req = global.doneSsr.request;
 		var cookie = req.headers && req.headers.cookie || "";
 
+		var waitingFunction = Zone.waitFor(noop);
+
 		var self = this;
-		this.addEventListener("load", Zone.waitFor(function () {
+		this.addEventListener("load", function(){
 			var setcookies = self.getResponseHeader( "Set-Cookie" );
 			if ( !setcookies ) {
+				waitingFunction();
 				return;
 			}
 			if ( !Array.isArray( setcookies ) ) {
@@ -21,7 +26,12 @@ module.exports = function(data){
 			for ( var i = 0; i < setcookies.length; i++ ) {
 				document.cookie = setcookies[ i ];
 			}
-		}));
+			waitingFunction();
+		});
+
+		this.addEventListener("error", function(){
+			waitingFunction();
+		});
 
 		// TODO:
 		// don't attach the cookies if the xhr url isn't the
@@ -51,12 +61,14 @@ module.exports = function(data){
 		ended: function(){
 			var doc = data.document;
 
-			var body = doc.body.getElementsByTagName("body")[0] || doc.body;
-			if(data.xhr) {
-				var xhrScript = doc.createElement("script");
-				var xhrTN = doc.createTextNode(data.xhr.toString());
-				xhrScript.appendChild(xhrTN);
-				body.insertBefore(xhrScript, body.lastChild);
+			if(doc) {
+				var body = doc.body.getElementsByTagName("body")[0] || doc.body;
+				if(data.xhr) {
+					var xhrScript = doc.createElement("script");
+					var xhrTN = doc.createTextNode(data.xhr.toString());
+					xhrScript.appendChild(xhrTN);
+					body.insertBefore(xhrScript, body.lastChild);
+				}
 			}
 		}
 	};

--- a/lib/zones/zones_test.js
+++ b/lib/zones/zones_test.js
@@ -1,3 +1,4 @@
+require("es6-promise").polyfill();
 var assert = require("assert");
 var Zone = require("can-zone");
 

--- a/lib/zones/zones_test.js
+++ b/lib/zones/zones_test.js
@@ -1,0 +1,79 @@
+var assert = require("assert");
+var Zone = require("can-zone");
+
+var xhrZone = require("./xhr");
+
+var helpers = require("../../test/helpers");
+
+describe("zones/xhr", function(){
+	describe("when successful", function(){
+		beforeEach(function(){
+			global.doneSsr = {
+				request: {}
+			};
+
+			this.oldXHR = global.XMLHttpRequest;
+			global.XMLHttpRequest = helpers.mockXHR('["a", "b", "c"]');
+
+			this.zone = new Zone({
+				plugins: [xhrZone]
+			});
+		});
+
+		afterEach(function(){
+			global.XMLHttpRequest = this.oldXHR;
+		});
+
+		it("Works", function(done){
+			this.zone.run(function(){
+				var xhr = new XMLHttpRequest();
+				xhr.open("GET", "foo.bar");
+				xhr.onload = function(){
+					var data = JSON.parse(xhr.responseText);
+					Zone.current.data.things = data;
+				};
+				xhr.send();
+			}).then(function(data){
+				assert.equal(data.things.length, 3, "got the xhr response");
+				done();
+			}, done);
+		});
+	});
+
+	describe("when errored", function(){
+		beforeEach(function(){
+			global.doneSsr = {
+				request: {}
+			};
+
+			this.oldXHR = global.XMLHttpRequest;
+			global.XMLHttpRequest = helpers.mockXHR(null, {
+				error: true
+			});
+
+			this.zone = new Zone({
+				plugins: [xhrZone]
+			});
+		});
+
+		afterEach(function(){
+			global.XMLHttpRequest = this.oldXHR;
+		});
+
+		it("Works", function(done){
+			this.zone.run(function(){
+				var xhr = new XMLHttpRequest();
+				xhr.open("GET", "foo.bar");
+				xhr.onerror = function(){
+					Zone.current.data.error = true;
+				};
+				xhr.send();
+			}).then(function(data){
+				assert.equal(data.error, true, "it errored");
+				done();
+			}, done);
+		});
+	});
+
+
+});

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "copy-dir": "0.0.8",
     "documentjs": "^0.3.0",
     "done-autorender": "^0.7.0",
+    "es6-promise": "^3.1.2",
     "jquery": ">=1.9.0 <1.12.0 || >=2.1.0 <2.2.0",
     "jshint": "^2.8.0",
     "spawn-mochas": "^1.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var mochas = require("spawn-mochas");
 
 mochas([
+	"unit_test.js",
 	"async_test.js",
 	"cookie_test.js",
 	"jquery_test.js",

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -1,0 +1,1 @@
+require("../lib/zones/zones_test");


### PR DESCRIPTION
The xhr Zone waits for XHR complete to copy the cookies over, however we
should not wait for the 'load' event because it might not happen.