### PR TITLE
Use onload wrapping rather than the eventlistener

### DIFF
--- a/lib/zones/xhr.js
+++ b/lib/zones/xhr.js
@@ -1,7 +1,4 @@
-var Zone = require("can-zone");
 var xhrZone = require("can-zone/xhr");
-
-var noop = function(){};
 
 module.exports = function(data){
 
@@ -11,13 +8,14 @@ module.exports = function(data){
 		var req = global.doneSsr.request;
 		var cookie = req.headers && req.headers.cookie || "";
 
-		var waitingFunction = Zone.waitFor(noop);
-
 		var self = this;
-		this.addEventListener("load", function(){
+		var onload = this.onload;
+		this.onload = function(){
 			var setcookies = self.getResponseHeader( "Set-Cookie" );
 			if ( !setcookies ) {
-				waitingFunction();
+				if(onload) {
+					return onload.apply(this, arguments);
+				}
 				return;
 			}
 			if ( !Array.isArray( setcookies ) ) {
@@ -26,12 +24,10 @@ module.exports = function(data){
 			for ( var i = 0; i < setcookies.length; i++ ) {
 				document.cookie = setcookies[ i ];
 			}
-			waitingFunction();
-		});
-
-		this.addEventListener("error", function(){
-			waitingFunction();
-		});
+			if(onload) {
+				return onload.apply(this, arguments);
+			}
+		};
 
 		// TODO:
 		// don't attach the cookies if the xhr url isn't the


### PR DESCRIPTION
Using the eventlistener forces us to use Zone.waitFor() which could
cause issues if the code throws. Instead use onload wrapping when will
make sure we stay within the zone.