### PR TITLE
Add a test showing empty import working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "done-ssr",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Server-side rendering for CanJS applications",
   "main": "lib/index.js",
   "scripts": {

--- a/test/import_empty_test.js
+++ b/test/import_empty_test.js
@@ -1,0 +1,30 @@
+var ssr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+var through = require("through2");
+
+describe("Projects importing a component that doesn't exist", function(){
+	this.timeout(10000);
+
+	before(function(){
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "import-empty/index.stache!done-autorender"
+		});
+	});
+
+	it("finishes rendering", function(done){
+		this.render("/").pipe(through(function(buffer){
+			var html = buffer.toString();
+			var node = helpers.dom(html);
+
+			var loading = helpers.find(node, function(el){
+				return el && el.id === "loading";
+			});
+
+			assert(loading, "Showing the loading element");
+			done();
+		}));
+	});
+});

--- a/test/import_empty_test.js
+++ b/test/import_empty_test.js
@@ -19,11 +19,11 @@ describe("Projects importing a component that doesn't exist", function(){
 			var html = buffer.toString();
 			var node = helpers.dom(html);
 
-			var loading = helpers.find(node, function(el){
-				return el && el.id === "loading";
+			var rej = helpers.find(node, function(el){
+				return el.getAttribute && el.getAttribute("id") === "rejected";
 			});
 
-			assert(loading, "Showing the loading element");
+			assert(rej, "Showing the rejected element");
 			done();
 		}));
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -10,5 +10,6 @@ mochas([
 	"plainjs_test.js",
 	"progressive_test.js",
 	"test_envs.js",
-	"xhr_test.js"
+	"xhr_test.js",
+	"import_empty_test.js"
 ], __dirname);

--- a/test/tests/import-empty/app.js
+++ b/test/tests/import-empty/app.js
@@ -1,0 +1,4 @@
+var route = require("can/route/");
+var Map = require("can/map/");
+
+module.exports = Map.extend({});

--- a/test/tests/import-empty/index.stache
+++ b/test/tests/import-empty/index.stache
@@ -5,11 +5,15 @@
 <body>
 	<can-import from="import-empty/app" export-as="viewModel"/>
 
-	<can-import from='import-empty/pages/home/'>
-	{{#if isResolved}}
-	  <some-page/>
+	<can-import from="import-empty/pages/home/">
+	{{#if isRejected}}
+		<span id="rejected">Didn't work</span>
 	{{else}}
-	  <span id="loading">Loading...</span>
+		{{#if isResolved}}
+		  <some-page/>
+		{{else}}
+		  <span id="loading">Loading...</span>
+		{{/if}}
 	{{/if}}
 	</can-import>
 </body>

--- a/test/tests/import-empty/index.stache
+++ b/test/tests/import-empty/index.stache
@@ -1,0 +1,16 @@
+<html>
+<head>
+	<title>DoneJS project</title>
+</head>
+<body>
+	<can-import from="import-empty/app" export-as="viewModel"/>
+
+	<can-import from='import-empty/pages/home/'>
+	{{#if isResolved}}
+	  <some-page/>
+	{{else}}
+	  <span id="loading">Loading...</span>
+	{{/if}}
+	</can-import>
+</body>
+</html>


### PR DESCRIPTION
This adds a test for the case where you are importing a module that
doesn't exist like:

```js
<can-import from="some/fake/module">

</can-import>
```

The `{{#if isRejected}}` section should be rendered. Closes #163