### PR TITLE
JWT Support: copy authorization header, if present.

### DIFF
--- a/lib/zones/xhr.js
+++ b/lib/zones/xhr.js
@@ -7,6 +7,10 @@ module.exports = function(data){
 	var send = function(){
 		var req = global.doneSsr.request;
 		var cookie = req.headers && req.headers.cookie || "";
+		var authHeader = req.headers && req.headers.authorization;
+	    if(authHeader){
+	        this.setRequestHeader('authorization', authHeader);
+	    }
 
 		var self = this;
 		var onload = this.onload;

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "copy-dir": "0.0.8",
     "documentjs": "^0.3.0",
     "done-autorender": "^0.7.0",
+    "done-ssr-middleware": "^0.1.5",
     "es6-promise": "^3.1.2",
     "jquery": "~2.2.1",
     "jshint": "^2.8.0",
+    "nock": "^8.0.0",
     "spawn-mochas": "^1.1.0",
     "through2": "^2.0.1"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ mochas([
 	"unit_test.js",
 	"async_test.js",
 	"cookie_test.js",
+	"token_test.js",
 	"jquery_test.js",
 	"leakscope_test.js",
 	"plain_state_test.js",

--- a/test/tests/token/appstate.js
+++ b/test/tests/token/appstate.js
@@ -1,0 +1,29 @@
+var AppMap = require("can/map/");
+
+require("can/map/define/");
+require("can/route/route");
+
+module.exports = AppMap.extend({
+	define: {
+		xhrResponse: {
+			get: function(last, set) {
+				var xhr = new XMLHttpRequest();
+				xhr.open("GET", "http://www.example.org/session");
+
+				xhr.addEventListener("load", function() {
+					set( this.responseText );
+				});
+				xhr.addEventListener("error", function() {
+					console.log( "err", this, arguments );
+				});
+
+				xhr.send();
+			}
+		},
+		gotResponse: {
+			get: function(){
+				return !!this.attr('xhrResponse');
+			}
+		}
+	}
+});

--- a/test/tests/token/index.stache
+++ b/test/tests/token/index.stache
@@ -1,0 +1,12 @@
+<html>
+	<head>
+		<title>authorization header / token test page</title>
+	</head>
+	<body>
+		<can-import from="token/appstate" as="viewModel" />
+
+		{{#if gotResponse}}
+			<span id="success"></span>
+		{{/if}}
+	</body>
+</html>

--- a/test/token_test.js
+++ b/test/token_test.js
@@ -1,0 +1,59 @@
+var path = require("path");
+var assert = require("assert");
+var ssr = require("../lib/");
+var helpers = require("./helpers");
+var through = require("through2");
+var nock = require("nock");
+// import the xhr polyfill
+require('done-ssr-middleware/lib/xhr');
+
+describe("authorization header / token async rendering", function() {
+	this.timeout(10000);
+	var render;
+
+	before(function(){
+		this.scope = nock("http://www.example.org", {
+				reqheaders: {"authorization": function(val){
+					return val === "fake-token";
+				}}
+			})
+			.get("/session")
+			.delay(20)
+			.reply(
+			function (uri, requestBody) {
+				return [
+					200,
+					'["one","two"]'
+				];
+			}
+		);
+		render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "token/index.stache!done-autorender"
+		});
+	});
+
+	after(function(){
+		nock.restore();
+	});
+
+
+	it( "works", function(done){
+		var stream = render({
+			//mocked up req object
+			url: "/",
+			headers: {
+				authorization: "fake-token"
+			}
+		});
+
+		stream.pipe(through(function(buffer){
+			var html = buffer.toString();
+			var node = helpers.dom(html);
+			var successSpan = node.getElementById( "success" );
+			assert.ok(successSpan);
+
+			done();
+		}));
+	});
+});


### PR DESCRIPTION
This adds compatibility for using SSR with JWT tokens or any auth based on the `authorization` request header.
This brings in the done-ssr-middleware to access its XHR polyfill.