### PR TITLE
update to steal 0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "can": "^2.3.0-pre || ^2.3.0-beta || ^2.3.0",
     "can-zone": "^0.5.0",
     "lodash.defaults": "^4.0.1",
-    "steal": "^0.15.0"
+    "steal": "^0.16.0"
   },
   "system": {
     "npmDependencies": [


### PR DESCRIPTION
lets try to update to steal 0.16

a user find a issue with donejs-react
https://gitter.im/donejs/donejs?at=571cf8fc6e3ae55e37e99529

the problem is/was, that done-ssr was using the old steal 0.15.
