### PR TITLE
Emit an error when encountering an error with steal.startup()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -154,6 +154,8 @@ module.exports = function(cfg, options){
 				// Cleanup the dom
 				trigger(doc, "removed");
 			});
+		}, function(error){
+			stream.emit("error", error);
 		});
 	};
 

--- a/test/startup_err_test.js
+++ b/test/startup_err_test.js
@@ -1,0 +1,27 @@
+var ssr = require("../lib/");
+var assert = require("assert");
+var path = require("path");
+var through = require("through2");
+
+describe("Error during steal.startup()", function(){
+	this.timeout(10000);
+
+	before(function(){
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "startup_err/index.stache!done-autorender"
+		});
+	});
+
+	it("Emits an error event", function(done){
+		var renderStream = this.render("/");
+		renderStream.pipe(through(function(){
+			done(new Error("Should not have rendered"));
+		}));
+
+		renderStream.on("error", function(err){
+			assert(/foo is not defined/.test(err.message), "Got the right error");
+			done();
+		});
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -13,5 +13,6 @@ mochas([
 	"test_envs.js",
 	"xhr_test.js",
 	"import_empty_test.js",
-	"timeout_test.js"
+	"timeout_test.js",
+	"startup_err_test.js"
 ], __dirname);

--- a/test/tests/startup_err/index.stache
+++ b/test/tests/startup_err/index.stache
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>test page</title>
+	</head>
+	<body>
+		<can-import from="startup_err/state" as="viewModel" />
+	</body>
+</html>

--- a/test/tests/startup_err/state.js
+++ b/test/tests/startup_err/state.js
@@ -1,0 +1,3 @@
+var Map = require("can/map/");
+
+foo();


### PR DESCRIPTION
This closes #173.

When steal encounters an errors starting up, that should propagate to
any stream that tries to render.