### PR TITLE
Move XHR and WebSocket polyfills into this library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,9 @@ var assetsZone = require("./zones/assets");
 var html5shivZone = require("./zones/html5");
 var responseZone = require("./zones/response");
 
+require("./polyfills/websocket");
+require("./polyfills/xhr");
+
 global.doneSsr = {};
 
 var doctype = "<!DOCTYPE html>";

--- a/lib/polyfills/websocket.js
+++ b/lib/polyfills/websocket.js
@@ -1,0 +1,1 @@
+global.WebSocket = require("websocket").w3cwebsocket;

--- a/lib/polyfills/xhr.js
+++ b/lib/polyfills/xhr.js
@@ -1,0 +1,40 @@
+var url = require("url");
+var xhr = require("xmlhttprequest").XMLHttpRequest;
+var fullUrl = /^https?:\/\//i;
+
+var XHR = global.XMLHttpRequest = function() {
+	xhr.apply(this, arguments);
+	this._hackSend = this.send;
+	this.send = XHR.prototype.send;
+
+	this._hackOpen = this.open;
+	this.open = XHR.prototype.open;
+
+	// In browsers these default to null
+	this.onload = null;
+	this.onerror = null;
+
+	// jQuery checks for this property to see if XHR supports CORS
+	this.withCredentials = true;
+};
+
+XHR.prototype.open = function() {
+	var req = global.doneSsr.request;
+	var baseUri = req.url || "";
+	if (req.protocol && req.get) {
+		baseUri = req.protocol + '://' + req.get("host") + baseUri;
+	}
+	var args = Array.prototype.slice.call(arguments);
+	var reqURL = args[1];
+
+	if ( reqURL && !fullUrl.test( reqURL ) ) {
+		args[1] = url.resolve( baseUri, reqURL );
+	}
+
+	return this._hackOpen.apply(this, args);
+};
+
+
+XHR.prototype.send = function () {
+	return this._hackSend.apply(this, arguments);
+};

--- a/lib/polyfills/xhr.md
+++ b/lib/polyfills/xhr.md
@@ -1,0 +1,86 @@
+### Server -> Client
+
+
+Cookies are only on a raw http response IF the server updated or created them during the request like so:
+
+```
+HTTP/1.1 200 OK
+X-Powered-By: Express
+set-cookie: testHTTPONLY=87; Max-Age=900; Path=/; Expires=Fri, 19 Feb 2016 14:13:11 GMT; HttpOnly
+set-cookie: test2=11; Max-Age=900; Path=/; Expires=Fri, 19 Feb 2016 14:13:11 GMT
+set-cookie: connect.sid=s%3AfKbjY9Uy8M4E7Qs9ERU1NtHy6Z_TsCjy.64IN0pnrAdpoKDPrZasDyjomq57GxcqOtofcA5YAjug; Path=/; HttpOnly
+Content-Type: text/html; charset=utf-8
+Content-Length: 3660
+ETag: W/"vojxRoHVYHVnAwyNy2ZUAQ=="
+Date: Fri, 19 Feb 2016 13:58:11 GMT
+Connection: keep-alive
+```
+
+They can be read on the express response object like this:
+
+```
+RespObj = {
+    _headers: {
+        'set-cookie': ['testHTTPONLY=87; Max-Age=900; Path=/; Expires=Fri, 19 Feb 2016 14:13:11 GMT; HttpOnly',
+            'test2=11; Max-Age=900; Path=/; Expires=Fri, 19 Feb 2016 14:13:11 GMT',
+            'connect.sid=s%3AfKbjY9Uy8M4E7Qs9ERU1NtHy6Z_TsCjy.64IN0pnrAdpoKDPrZasDyjomq57GxcqOtofcA5YAjug; Path=/; HttpOnly'
+        ]
+    }
+}
+```
+
+"set-cookie" will only be an array if there is more than one, otherwise it's a string.
+
+Any cookie that is flagged 'HttpOnly' is inaccessable from JavaScript in modern browsers but it is still stored in the browser and the key=value of those cookies is still sent with requests.
+
+
+
+### Client -> Server
+
+All active cookies are on the raw http request but it's only their key=value pairs; The other information is not sent:
+
+```
+GET /players HTTP/1.1
+Host: localhost:5000
+Connection: keep-alive
+Pragma: no-cache
+Cache-Control: no-cache
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Upgrade-Insecure-Requests: 1
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.86 Safari/537.36
+Accept-Encoding: gzip, deflate, sdch
+Accept-Language: en-US,en;q=0.8
+Cookie: test1=0; testHTTPONLY=87; test2=11; connect.sid=s%3AWDhHXtizN4kCsPRslGJbteG_9FCm9mhN.%2BVCJdldBBSw8F1QwU%2FppaTYbACyfnNEb2aS%2BSBf0sko
+```
+
+The request cookies even include the key value pairs of HttpOnly cookies even though `document.cookie -> "test1=0; test2=11"`.
+
+They can be read on the express request object like this:
+
+```
+ReqObj = {
+  headers: {
+    cookie: 'test1=0; testHTTPONLY=87; test2=11; connect.sid=s%3AWDhHXtizN4kCsPRslGJbteG_9FCm9mhN.%2BVCJdldBBSw8F1QwU%2FppaTYbACyfnNEb2aS%2BSBf0sko'
+  }
+}
+```
+
+If you `$ npm install cookie-parser --save` and set up the server to use it:
+
+```
+var cookieParser = require('cookie-parser');
+app.use( cookieParser() );
+```
+
+Then you can also access the cookies like so:
+
+```
+ReqObj = {
+  cookies: {
+    test1: '0',
+    testHTTPONLY: '87',
+    test2: '11',
+    'connect.sid': 's:fKbjY9Uy8M4E7Qs9ERU1NtHy6Z_TsCjy.64IN0pnrAdpoKDPrZasDyjomq57GxcqOtofcA5YAjug'
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/donejs/done-ssr",
   "devDependencies": {
+    "can-fixture": "^0.1.2",
     "copy-dir": "0.0.8",
     "documentjs": "^0.3.0",
     "done-autorender": "^0.7.0",
@@ -46,7 +47,9 @@
     "can": "^2.3.0-pre || ^2.3.0-beta || ^2.3.0",
     "can-zone": "^0.5.0",
     "lodash.defaults": "^4.0.1",
-    "steal": "^0.16.0"
+    "steal": "^0.16.0",
+    "websocket": "^1.0.22",
+    "xmlhttprequest": "^1.8.0"
   },
   "system": {
     "npmDependencies": [

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -7,7 +7,9 @@ var modules = [
 	"simple-html-tokenizer",
 	"jquery",
 	"done-autorender",
-	"can-zone"
+	"can-zone",
+	"can-fixture",
+	"can-set"
 ];
 
 modules.forEach(function(name){

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -1,0 +1,42 @@
+var assert = require("assert");
+var path = require("path");
+var nock = require("nock");
+var through = require("through2");
+
+var ssr = require("../lib/index");
+
+describe("Using can-fixture", function(){
+	this.timeout(10000);
+
+	before(function(){
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "fixtures/index.stache!done-autorender"
+		});
+
+		this.scope = nock("http://www.example.org")
+			.get("/stuff")
+			.delay(20)
+			.reply(
+			function (uri, requestBody) {
+				return [
+					200,
+					'["one","two"]'
+				];
+			}
+		);
+	});
+
+	after(function(){
+		nock.restore();
+	});
+
+
+	it("Returns a response", function(done){
+		var response = through(function(buffer){
+			assert.equal(response.statusCode, 200, "Got a 200 response");
+			done();
+		});
+		this.render("/").pipe(response);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -14,5 +14,6 @@ mochas([
 	"xhr_test.js",
 	"import_empty_test.js",
 	"timeout_test.js",
-	"startup_err_test.js"
+	"startup_err_test.js",
+	"fixture_test.js"
 ], __dirname);

--- a/test/tests/fixtures/appstate.js
+++ b/test/tests/fixtures/appstate.js
@@ -1,0 +1,23 @@
+var List = require("can/list/");
+var Map = require("can/map/");
+require("can/map/define/");
+
+module.exports = Map.extend({
+	define: {
+		things: {
+			Value: List,
+			get: function(list){
+				var xhr = new XMLHttpRequest();
+				xhr.open("GET", "http://www.example.org/stuff");
+				xhr.addEventListener("load", function(){
+					var json = xhr.responseText;
+					var data = JSON.parse(json);
+					list.replace(data);
+				});
+				xhr.send();
+
+				return list;
+			}
+		}
+	}
+});

--- a/test/tests/fixtures/fixtures.js
+++ b/test/tests/fixtures/fixtures.js
@@ -1,0 +1,20 @@
+var fixture = require("can-fixture");
+
+var store = fixture.store([
+	{ id: 3, text: "three" },
+	{ id: 4, text: "four" }
+]);
+
+fixture({
+  'GET /stuff': store.findAll,
+  'GET /stuff/{id}': store.findOne,
+  'POST /stuff': function (req, res){
+  	return ""+Math.random();
+  },
+  'PUT /stuff/{id}': store.update,
+  'DELETE /stuff/{id}': store.destroy
+});
+
+fixture.delay = 20;
+
+module.exports = store;

--- a/test/tests/fixtures/index.stache
+++ b/test/tests/fixtures/index.stache
@@ -1,0 +1,14 @@
+<html>
+	<head>
+		<title>test page</title>
+	</head>
+	<body>
+		<can-import from="./fixtures/routes"/>
+		<can-import from="fixtures/appstate" as="viewModel" />
+		<can-import from="fixtures/fixtures"/>
+
+		{{#things}}
+			<div>{{.}}</div>
+		{{/things}}
+	</body>
+</html>

--- a/test/tests/fixtures/npm-debug.log
+++ b/test/tests/fixtures/npm-debug.log
@@ -1,0 +1,26 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/Users/matthew/.nvm/versions/node/v5.8.0/bin/node',
+1 verbose cli   '/Users/matthew/.nvm/versions/node/v5.8.0/bin/npm',
+1 verbose cli   'run',
+1 verbose cli   'copy' ]
+2 info using npm@3.7.3
+3 info using node@v5.8.0
+4 verbose stack Error: missing script: copy
+4 verbose stack     at run (/Users/matthew/.nvm/versions/node/v5.8.0/lib/node_modules/npm/lib/run-script.js:147:19)
+4 verbose stack     at /Users/matthew/.nvm/versions/node/v5.8.0/lib/node_modules/npm/lib/run-script.js:57:5
+4 verbose stack     at /Users/matthew/.nvm/versions/node/v5.8.0/lib/node_modules/npm/node_modules/read-package-json/read-json.js:345:5
+4 verbose stack     at checkBinReferences_ (/Users/matthew/.nvm/versions/node/v5.8.0/lib/node_modules/npm/node_modules/read-package-json/read-json.js:309:45)
+4 verbose stack     at final (/Users/matthew/.nvm/versions/node/v5.8.0/lib/node_modules/npm/node_modules/read-package-json/read-json.js:343:3)
+4 verbose stack     at then (/Users/matthew/.nvm/versions/node/v5.8.0/lib/node_modules/npm/node_modules/read-package-json/read-json.js:113:5)
+4 verbose stack     at ReadFileContext.<anonymous> (/Users/matthew/.nvm/versions/node/v5.8.0/lib/node_modules/npm/node_modules/read-package-json/read-json.js:284:20)
+4 verbose stack     at ReadFileContext.callback (/Users/matthew/.nvm/versions/node/v5.8.0/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:78:16)
+4 verbose stack     at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:324:13)
+5 verbose cwd /Users/matthew/Projects/done-ssr/test/tests/fixtures
+6 error Darwin 15.3.0
+7 error argv "/Users/matthew/.nvm/versions/node/v5.8.0/bin/node" "/Users/matthew/.nvm/versions/node/v5.8.0/bin/npm" "run" "copy"
+8 error node v5.8.0
+9 error npm  v3.7.3
+10 error missing script: copy
+11 error If you need help, you may report this error at:
+11 error     <https://github.com/npm/npm/issues>
+12 verbose exit [ 1, true ]

--- a/test/tests/fixtures/routes.js
+++ b/test/tests/fixtures/routes.js
@@ -1,0 +1,4 @@
+var route = require("can/route/route");
+require("can/route/pushstate/pushstate");
+
+route(":page", { page: "home" });

--- a/test/tests/package.json
+++ b/test/tests/package.json
@@ -4,6 +4,7 @@
   "main": "progressive/index.stache!done-autorender",
   "dependencies": {
     "can": "^2.3.0",
+    "can-fixture": "^0.1.2",
 	"jquery": "~2.2.1",
     "done-autorender": "0.0.7"
   },


### PR DESCRIPTION
This moves the XHR and WebSocket polyfills into this library. This is so
that users do not need to provide their own.

Closes #175