### PR TITLE
Make `steal` available as a global within each Zone

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ module.exports = function(cfg, options){
 			var render = makeRender(main);
 
 			var zonePlugins = [
-				ssrGlobalsZone(doc, request, loader),
+				ssrGlobalsZone(doc, request, loader, steal),
 				canRouteDataZone,
 				assetsZone(doc, bundleHelpers),
 				responseZone(stream)

--- a/lib/zones/globals.js
+++ b/lib/zones/globals.js
@@ -1,6 +1,6 @@
 var url = require("url");
 
-module.exports = function(document, request, loader){
+module.exports = function(document, request, loader, steal){
 	return function(data){
 		var location = url.parse(request.url, true);
 		document.location = location;
@@ -11,7 +11,8 @@ module.exports = function(document, request, loader){
 			globals: {
 				"can.document": document,
 				"doneSsr.request": request,
-				"doneSsr.loader": loader
+				"doneSsr.loader": loader,
+				"steal": steal
 			},
 
 			created: function(){

--- a/test/stealdone_test.js
+++ b/test/stealdone_test.js
@@ -23,7 +23,6 @@ describe("Using steal.done() in a module", function(){
 		stream.pipe(through(function(buffer){
 			var html = buffer.toString();
 			var node = helpers.dom(html);
-			console.log(html);
 
 			var tn = helpers.find(node, function(node){
 				return node.nodeType === 3;

--- a/test/stealdone_test.js
+++ b/test/stealdone_test.js
@@ -1,0 +1,36 @@
+var ssr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+var through = require("through2");
+
+describe("Using steal.done() in a module", function(){
+	this.timeout(10000);
+
+	before(function(){
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "stealdone/main"
+		});
+	});
+
+	it("returns a Promise", function(done){
+		var render = this.render;
+
+		var stream = render("/");
+		stream.on("error", done);
+
+		stream.pipe(through(function(buffer){
+			var html = buffer.toString();
+			var node = helpers.dom(html);
+			console.log(html);
+
+			var tn = helpers.find(node, function(node){
+				return node.nodeType === 3;
+			});
+
+			assert.equal(tn.nodeValue, "object");
+			done();
+		}));
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -17,5 +17,6 @@ mochas([
 	"timeout_test.js",
 	"startup_err_test.js",
 	"fixture_test.js",
-	"nojquery_test.js"
+	"nojquery_test.js",
+	"stealdone_test.js"
 ], __dirname);

--- a/test/tests/stealdone/main.js
+++ b/test/tests/stealdone/main.js
@@ -1,0 +1,7 @@
+module.exports = function(request){
+	var def = typeof steal.done();
+	var span = document.createElement("span");
+	span.innerHTML = def;
+
+	document.body.appendChild(span);
+};


### PR DESCRIPTION
This fixes #194. If you use the global `steal` it would always refer to
the global steal and not the locally created one. This fixes that by
making it be set inside of the Zone.