### PR TITLE
Make `steal` available as a global within each Zone

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ module.exports = function(cfg, options){
 			var render = makeRender(main, can);
 
 			var zonePlugins = [
-				ssrGlobalsZone(doc, request, loader, modules),
+				ssrGlobalsZone(doc, request, loader, steal, modules),
 				canRouteDataZone(can),
 				assetsZone(doc, bundleHelpers, can),
 				responseZone(stream)

--- a/lib/zones/globals.js
+++ b/lib/zones/globals.js
@@ -1,6 +1,6 @@
 var url = require("url");
 
-module.exports = function(document, request, loader, modules){
+module.exports = function(document, request, loader, steal, modules){
 	var DOCUMENT = modules.DOCUMENT || function(){};
 
 	return function(data){
@@ -14,7 +14,8 @@ module.exports = function(document, request, loader, modules){
 			location: location,
 			globals: {
 				"doneSsr.request": request,
-				"doneSsr.loader": loader
+				"doneSsr.loader": loader,
+				"steal": steal
 			},
 
 			created: function(){

--- a/test/stealdone_test.js
+++ b/test/stealdone_test.js
@@ -1,0 +1,35 @@
+var ssr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+var through = require("through2");
+
+describe("Using steal.done() in a module", function(){
+	this.timeout(10000);
+
+	before(function(){
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "stealdone/main"
+		});
+	});
+
+	it("returns a Promise", function(done){
+		var render = this.render;
+
+		var stream = render("/");
+		stream.on("error", done);
+
+		stream.pipe(through(function(buffer){
+			var html = buffer.toString();
+			var node = helpers.dom(html);
+
+			var tn = helpers.find(node, function(node){
+				return node.nodeType === 3;
+			});
+
+			assert.equal(tn.nodeValue, "object");
+			done();
+		}));
+	});
+});


### PR DESCRIPTION
This fixes #194. If you use the global `steal` it would always refer to
the global steal and not the locally created one. This fixes that by
making it be set inside of the Zone.