### PR TITLE
Recover from live-reload problems

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ module.exports = function(cfg, options){
 	});
 	var steal = Steal.clone();
 	var loader = global.System = steal.System;
+	var isACanProject;
 
 	var nodeEnv = process.env.NODE_ENV || "development";
 	loader.config({
@@ -48,7 +49,16 @@ module.exports = function(cfg, options){
 	var bundleHelpers = traceBundles(loader);
 
 	var startup = stealStartup(steal, function(mainPromise){
-		startup = mainPromise;
+		var oldStartup = startup;
+		startup = mainPromise.then(function(modules){
+			// We were unable to reload the can modules which means
+			// there is some bug. But we can continue to render anyways.
+			if(isACanProject && !modules.can) {
+				return oldStartup;
+			}
+
+			return modules;
+		});
 	});
 
 	var SSRStream = function(requestOrUrl){
@@ -71,6 +81,11 @@ module.exports = function(cfg, options){
 		return startup.then(function(modules){
 			var main = modules.main;
 			var can = modules.can;
+
+			// Save whether this is a can project or not.
+			if(isACanProject === undefined) {
+				isACanProject = !!can;
+			}
 
 			var request = typeof requestOrUrl === "string" ?
 				{ url: requestOrUrl } : requestOrUrl;
@@ -153,7 +168,17 @@ module.exports = function(cfg, options){
 	};
 
 
-	return function(requestOrUrl){
+	var makeRenderStream = function(requestOrUrl){
 		return new SSRStream(requestOrUrl);
 	};
+
+	// Expose the loader
+	makeRenderStream.loader = loader;
+
+	// Expose the startup promise
+	Object.defineProperty(makeRenderStream, "startupPromise", {
+		get: function() { return startup; }
+	});
+
+	return makeRenderStream;
 };

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -72,4 +72,3 @@ function getMainModule(main){
 	main = Array.isArray(main) ? main[0] : main;
 	return main.importPromise || Promise.resolve(main);
 }
-

--- a/test/live-reload_test.js
+++ b/test/live-reload_test.js
@@ -1,0 +1,53 @@
+var ssr = require("../lib/");
+var assert = require("assert");
+var path = require("path");
+var through = require("through2");
+
+describe("live-reload", function(){
+	this.timeout(10000);
+
+	before(function(){
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "lr/index.stache!done-autorender",
+			liveReloadHost: "localhost",
+			configDependencies: [
+				"live-reload"
+			]
+		});
+	});
+
+	it("Initially works", function(done){
+		var renderStream = this.render("/");
+		renderStream.pipe(through(function(){
+			assert.ok(true, "Rendered");
+			done();
+		}));
+	});
+
+	it("A failure in live-reload doesn't prevent it from still working", function(done){
+		var render = this.render;
+		render.startupPromise
+		.then(function(){
+			var loader = render.loader;
+			var liveReload = loader.get("live-reload").default;
+
+			// Remove a module that is needed for ssr to run.
+			return loader.normalize("can-util/namespace", "@ssr")
+			.then(function(name){
+				loader["delete"](name);
+			})
+			.then(function(){
+				return liveReload(loader.main);
+			});
+		})
+		.then(function(){
+			// Now render a page.
+			var renderStream = render("/");
+			renderStream.pipe(through(function(){
+				assert.ok(true, "Rendering worked!");
+				done();
+			}));
+		});
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -18,5 +18,6 @@ mochas([
 	"nojquery_test.js",
 	"stealdone_test.js",
 	"define_map_test.js",
-	"define_test.js"
+	"define_test.js",
+	"live-reload_test.js"
 ], __dirname);

--- a/test/tests/lr/index.stache
+++ b/test/tests/lr/index.stache
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>test page</title>
+	</head>
+	<body>
+		<can-import from="lr/state" as="viewModel" />
+	</body>
+</html>

--- a/test/tests/lr/state.js
+++ b/test/tests/lr/state.js
@@ -1,0 +1,3 @@
+var Map = require("can-map");
+
+module.exports = Map.extend({});


### PR DESCRIPTION
This makes us more resilent to live-reload bugs which could cause us to
not be able to retrieve the newest can namespace object. When this
happens we can just continue to use the previous can namespace object
and at least render with that.

Closes #213