### PR TITLE
Use can.route.matched() to determine if a route matched

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ module.exports = function(cfg, options){
 			return zone.run(function(){
 				render(request);
 
-				if(can.route) {
+				if(isACanProject && can.route) {
 					zone.data.viewModel = can.route.data;
 				}
 			}).then(null, function(err){

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,9 @@ module.exports = function(cfg, options){
 				doc.head = doc.createElement("head");
 				doc.documentElement.insertBefore(doc.head, doc.body);
 			}
+
+			// Create a renderer function that when calls will
+			// render into a virtual DOM.
 			var render = makeRender(main, can);
 
 			var zonePlugins = [
@@ -131,9 +134,11 @@ module.exports = function(cfg, options){
 			});
 
 			return zone.run(function(){
-
 				render(request);
 
+				if(can.route) {
+					zone.data.viewModel = can.route.data;
+				}
 			}).then(null, function(err){
 				if(!(err instanceof TimeoutError)) {
 					throw err;

--- a/lib/make_render.js
+++ b/lib/make_render.js
@@ -10,7 +10,8 @@ module.exports = function(main, can){
 			var state = createState(request);
 
 			if(hasCanRoute(can)) {
-				can.route.map(state);
+				can.route.data = state;
+				can.route.ready();
 			}
 
 			return main.render(document, state);

--- a/lib/zones/route_data.js
+++ b/lib/zones/route_data.js
@@ -1,9 +1,10 @@
 var attr = require("../attr");
+var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
 
 // Override can.route.data on every Task execution
 module.exports = function(can){
 	return function(data){
-		var oldData, viewModel, noop = function(){};
+		var oldData, viewModel, noop = function(){}, hasBound = false;
 
 		function routeData(value) {
 			var isSetter = !!arguments.length;
@@ -21,35 +22,52 @@ module.exports = function(can){
 			return typeof can !== "undefined" && !!can.route;
 		}
 
-		return {
-			created: function(){
-				// We need to know when can.route.data is set the first time so
-				// we have the viewModel to continuously set before each task.
-				if(hasCanRoute()) {
-					var oldMap = can.route.map;
-					can.route.map = function(data){
-						viewModel = data;
-						viewModel.bind("statusCode", noop);
-						can.route.map = oldMap;
-					};
+		function hasRoutes() {
+			return hasCanRoute() && !isEmptyObject(can.route.routes);
+		}
+
+		function extractStatusCode(viewModel) {
+			var statusCode = attr.get(viewModel, "statusCode");
+
+			if(!statusCode) {
+				if(hasRoutes()) {
+					var currentRoute = can.route.matched();
+					// If there is no current route it is likely a 404
+					if(!currentRoute) {
+						statusCode = 404;
+					} else {
+						statusCode = 200;
+					}
+				} else {
+					statusCode = 200;
 				}
-			},
+			}
+
+			return statusCode;
+		}
+
+		return {
 			beforeTask: function(){
-				if(hasCanRoute() && !!viewModel) {
+				if(hasCanRoute() && !!data.viewModel) {
 					oldData = routeData();
 					routeData(viewModel);
 				}
+				if(data.viewModel && !hasBound) {
+					hasBound = true;
+					data.viewModel.addEventListener('statusCode', noop);
+				}
 			},
 			afterTask: function(){
-				if(hasCanRoute() && !!viewModel) {
+				if(hasCanRoute() && !!data.viewModel) {
 					routeData(oldData);
 				}
 			},
 			ended: function(){
+				var viewModel = data.viewModel;
 				if(viewModel) {
-					data.statusCode = attr.get(viewModel, "statusCode");
+					data.statusCode = extractStatusCode(viewModel);
 					data.state = viewModel;
-					viewModel.unbind("statusCode", noop);
+					viewModel.removeEventListener('statusCode', noop);
 				}
 			}
 		};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "can-map": "^3.0.4",
     "can-map-define": "^3.0.2",
     "can-route": "^3.0.6",
-    "can-route-pushstate": "^3.0.1",
+    "can-route-pushstate": "^3.0.3",
     "can-stache": "^3.0.16",
     "copy-dir": "0.0.8",
     "documentjs": "^0.4.4",

--- a/test/define_map_status_test.js
+++ b/test/define_map_status_test.js
@@ -11,7 +11,7 @@ describe("Using can-define/map/map", function(){
 	before(function(){
 		this.render = ssr({
 			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
-			main: "define-map/index.stache!done-autorender"
+			main: "define-map-status/index.stache!done-autorender"
 		});
 	});
 
@@ -22,17 +22,13 @@ describe("Using can-define/map/map", function(){
 
 			var worked = node.getElementById("worked");
 
-			Promise.resolve().then(function(){
-				assert.equal(response.statusCode, 200, "Correct response");
-				assert.ok(worked, "rendered the page");
-			})
-			.then(done, done);
-
+			assert.ok(worked, "rendered the page");
+			done();
 		});
 		this.render("/test").pipe(response);
 	});
 
-	it("Returns a 404 when there is no matching route", function(done){
+	it.only("Returns a 404 when there is no matching route", function(done){
 		var response = through(function(){
 			var statusCode = response.statusCode;
 			assert.equal(statusCode, 404, "Got a 404");

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ mochas([
 	"nojquery_test.js",
 	"stealdone_test.js",
 	"define_map_test.js",
+	"define_map_status_test.js",
 	"define_test.js",
 	"live-reload_test.js"
 ], __dirname);

--- a/test/tests/define-map-status/index.stache
+++ b/test/tests/define-map-status/index.stache
@@ -1,0 +1,12 @@
+<html>
+<head>
+<title></title>
+</head>
+<body>
+	<can-import from="define-map-status/vm" export-as="viewModel"/>
+
+	{{#eq page "test"}}
+		<div id="worked">It worked</div>
+	{{/eq}}
+</body>
+</html>

--- a/test/tests/define-map-status/vm.js
+++ b/test/tests/define-map-status/vm.js
@@ -1,0 +1,10 @@
+var DefineMap = require("can-define/map/map");
+var route = require("can-route");
+require("can-route-pushstate");
+
+route("{page}");
+
+module.exports = DefineMap.extend({
+	page: "string",
+	statusCode: "number"
+});


### PR DESCRIPTION
This changes the behavior of 404s, so that we use the
can.route.matched() compute to determine if a route was matched when
rendering. This is used to determine which `statusCode` is used, if the
user doesn't provide it themselves on their ViewModel.

Also adds a few tests to make sure this works with DefineMaps. Closes #217