### PR TITLE
Cache normalize calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 script: npm test
 node_js:
-  - "4"
   - "6"
   - "7"

--- a/lib/configure_loader.js
+++ b/lib/configure_loader.js
@@ -1,15 +1,21 @@
+var Deferred = require("./deferred");
 var pkg = require("../package.json");
 
 global.navigator = global.navigator || {
 	userAgent: "Mozilla/5.0 " + "done-ssr/" + pkg.version
 };
 
-module.exports = function(loader){
+module.exports = function(steal, options){
+	var loader = steal.loader;
+	var stealDone = new Deferred();
+
 	// Ensure the extension loads before the main.
 	var loaderImport = loader.import;
 	loader.import = function(name){
 		if(name === loader.main) {
 			var args = arguments;
+
+			steal.done().then(stealDone.resolve);
 
 			// Set up the default renderingBaseURL which plugins use to
 			// create addresses for assets when baseURL is pointing to
@@ -26,4 +32,37 @@ module.exports = function(loader){
 		}
 		return loaderImport.apply(this, arguments);
 	};
+
+	if(options.useCacheNormalize) {
+		stealDone.promise.then(addCacheNormalize.bind(null, loader));
+	}
 };
+
+function addCacheNormalize(loader) {
+	var getCacheName = function(identifier, parentName){
+		var parentModuleName = parentName || "@none";
+		var cacheName = identifier + "+" + parentModuleName;
+		return cacheName;
+	};
+
+	loader._normalizeCache = Object.create(null);
+
+	var normalize = loader.normalize;
+	loader.normalize = function(name, parentName){
+		var cacheName = getCacheName(name, parentName);
+		var cache = this._normalizeCache;
+
+		if(cacheName in cache) {
+			var moduleName = cache[cacheName];
+			if(moduleName in this._loader.modules) {
+				return Promise.resolve(moduleName);
+			}
+		}
+
+		return Promise.resolve(normalize.apply(this, arguments))
+		.then(function(normalizedName) {
+			cache[cacheName] = normalizedName;
+			return normalizedName;
+		});
+	};
+}

--- a/lib/deferred.js
+++ b/lib/deferred.js
@@ -1,0 +1,10 @@
+
+function Deferred() {
+	var dfd = this;
+	this.promise = new Promise(function(resolve, reject){
+		dfd.resolve = resolve;
+		dfd.reject = reject;
+	});
+}
+
+module.exports = Deferred;

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,8 @@ var doctype = "<!DOCTYPE html>";
 module.exports = function(cfg, options){
 	cfg = cfg || {};
 	options = defaults(options, {
-		timeout: 5000
+		timeout: 5000,
+		useCacheNormalize: true
 	});
 	var steal = Steal.clone();
 	var loader = global.System = steal.System;
@@ -45,7 +46,7 @@ module.exports = function(cfg, options){
 	steal.config(cfg);
 
 	// Configure the loader so that the virtual DOM is loaded
-	configureLoader(loader);
+	configureLoader(steal, options);
 	var bundleHelpers = traceBundles(loader);
 
 	var startup = stealStartup(steal, function(mainPromise){

--- a/test/cache-normalize_test.js
+++ b/test/cache-normalize_test.js
@@ -1,0 +1,51 @@
+var assert = require("assert");
+var path = require("path");
+var through = require("through2");
+
+var ssr = require("../lib/index");
+
+describe("useCacheNormalize", function(){
+	this.timeout(10000);
+
+	describe("By default", function(){
+		before(function(){
+			this.render = ssr({
+				config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+				main: "define/index.stache!done-autorender"
+			});
+		});
+
+		it("cache is used", function(done){
+			var loader = this.render.loader;
+			var response = through(function(buffer){
+				assert.ok("_normalizeCache" in loader, "The cache was added");
+
+				done();
+			});
+			this.render("/").pipe(response);
+		});
+	});
+
+	describe("When turned off", function(){
+		before(function(){
+			this.render = ssr({
+				config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+				main: "define/index.stache!done-autorender"
+			}, {
+				useCacheNormalize: false
+			});
+		});
+
+		it("cache is not used", function(done){
+			var loader = this.render.loader;
+			var response = through(function(buffer){
+				assert.ok(!("_normalizeCache" in loader), "The cache was not added");
+
+				done();
+			});
+			this.render("/").pipe(response);
+		});
+	});
+
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -20,5 +20,6 @@ mochas([
 	"define_map_test.js",
 	"define_map_status_test.js",
 	"define_test.js",
-	"live-reload_test.js"
+	"live-reload_test.js",
+	"cache-normalize_test.js"
 ], __dirname);


### PR DESCRIPTION
This makes it so that SSR caches normalize calls after the app is fully loaded. This way any subsequent renders that call System.import don't encur the high normalization cost. Fixes #223