### PR TITLE
Support multiple rendering strategies

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,0 +1,25 @@
+var defaults = require("lodash.defaults");
+var Steal = require("steal");
+
+module.exports = function(config, options){
+	var cfg = config || {};
+	var opts = defaults(options, {
+		timeout: 5000,
+		useCacheNormalize: true
+	});
+	var steal = Steal.clone();
+	var loader = global.System = steal.System;
+
+	var nodeEnv = process.env.NODE_ENV || "development";
+	loader.config({
+		env: "server-" + nodeEnv
+	});
+
+	steal.config(cfg);
+
+    return {
+        steal: steal,
+        config: cfg,
+        options: opts
+    };
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ module.exports = function(cfg, options){
 				var dt = cfg.doctype || doctype;
 				html = dt + "\n" + html;
 
-				stream.push(html);
+				//stream.push(html);
 				stream.push(null);
 			}, function(error){
 				stream.emit("error", error);

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,8 @@ require("can-vdom");
 require("./polyfills/websocket");
 require("./polyfills/xhr");
 
+var SafeStream = require("./modes/safe");
+
 global.doneSsr = {};
 
 var doctype = "<!DOCTYPE html>";
@@ -62,121 +64,12 @@ module.exports = function(cfg, options){
 		});
 	});
 
-	var SSRStream = function(requestOrUrl){
-		Readable.call(this);
-		this.requestOrUrl = requestOrUrl;
-		this.dests = [];
-	};
-
-	util.inherits(SSRStream, Readable);
-
-	SSRStream.prototype._read = function(){
-		if(this._renderPromise) { return; }
-		this._renderPromise = this.render();
-	};
-
-	SSRStream.prototype.render = function(){
-		var stream = this;
-		var requestOrUrl = this.requestOrUrl;
-
-		return startup.then(function(modules){
-			var main = modules.main;
-			var can = modules.can;
-			var DOCUMENT = modules.DOCUMENT;
-			var domMutate = modules.domMutate;
-
-			// Save whether this is a can project or not.
-			if(isACanProject === undefined) {
-				isACanProject = !!can;
-			}
-
-			var request = typeof requestOrUrl === "string" ?
-				{ url: requestOrUrl } : requestOrUrl;
-
-			// Create the document
-			var doc = new document.constructor();
-
-			addCookies(doc, request);
-
-			var serializeFromBody = !!(main.renderAsync ||
-									   main.serializeFromBody);
-			if(!serializeFromBody) {
-				doc.head = doc.createElement("head");
-				doc.documentElement.insertBefore(doc.head, doc.body);
-			}
-
-			// Create a renderer function that when calls will
-			// render into a virtual DOM.
-			var render = makeRender(main, can);
-
-			var zonePlugins = [
-				ssrGlobalsZone(doc, request, loader, steal, modules),
-				canRouteDataZone(can),
-				assetsZone(doc, bundleHelpers, can),
-				responseZone(stream)
-			];
-
-			if(typeof XMLHttpRequest !== "undefined") {
-				zonePlugins.push(xhrZone(options));
-			}
-
-			if(options.html5shiv) {
-				zonePlugins.push(html5shivZone(can));
-			}
-
-			var timeoutZone = timeout(options.timeout);
-			zonePlugins.push(timeoutZone);
-
-			if(options.debug) {
-				var debugZone = debug(doc, timeoutZone);
-				zonePlugins.push(debugZone);
-			}
-
-			var zone = new Zone({
-				plugins: zonePlugins
-			});
-
-			return zone.run(function(){
-				render(request);
-
-				if(isACanProject && can.route) {
-					zone.data.viewModel = can.route.data;
-				}
-			}).then(null, function(err){
-				if(!(err instanceof TimeoutError)) {
-					throw err;
-				}
-			}).then(function(data){
-				var html;
-				if(serializeFromBody) {
-					html = doc.body.innerHTML;
-				} else {
-					html = doc.documentElement.outerHTML;
-				}
-
-				var dt = cfg.doctype || doctype;
-				html = dt + "\n" + html;
-
-				//stream.push(html);
-				stream.push(null);
-			}, function(error){
-				stream.emit("error", error);
-			}).then(function(){
-				cleanupDocument(doc, DOCUMENT, domMutate);
-			});
-		}, function(error){
-			stream.emit("error", error);
-		});
-	};
-
-	SSRStream.prototype.pipe = function(dest){
-		this.dests.push(dest);
-		return Readable.prototype.pipe.apply(this, arguments);
-	};
-
-
 	var makeRenderStream = function(requestOrUrl){
-		return new SSRStream(requestOrUrl);
+		var stream = new SafeStream(requestOrUrl);
+		Object.defineProperty(stream, "startup", {
+			get: function() { return startup; }
+		});
+		return stream;
 	};
 
 	// Expose the loader

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,13 @@
 var Readable = require("stream").Readable;
-var Steal = require("steal");
 var cleanupDocument = require("./cleanup");
 var configureLoader = require("./configure_loader");
 var Zone = require("can-zone");
+var makeContext = require("./context");
 var makeRender = require("./make_render");
 var addCookies = require( "./cookies" );
 var traceBundles = require("./bundles/index");
 var util = require("util");
-var defaults = require("lodash.defaults");
-var stealStartup = require("./startup");
+var ReloadableStartup = require("./reloadable-startup");
 
 var debug = require("./zones/debug");
 var timeout = require("can-zone/timeout");
@@ -30,54 +29,27 @@ global.doneSsr = {};
 
 var doctype = "<!DOCTYPE html>";
 
-module.exports = function(cfg, options){
-	cfg = cfg || {};
-	options = defaults(options, {
-		timeout: 5000,
-		useCacheNormalize: true
-	});
-	var steal = Steal.clone();
-	var loader = global.System = steal.System;
-	var isACanProject;
-
-	var nodeEnv = process.env.NODE_ENV || "development";
-	loader.config({
-		env: "server-" + nodeEnv
-	});
-
-	steal.config(cfg);
+module.exports = function(config, options){
+	var context = makeContext(config, options);
 
 	// Configure the loader so that the virtual DOM is loaded
-	configureLoader(steal, options);
-	var bundleHelpers = traceBundles(loader);
+	configureLoader(context.steal, context.options);
+	var bundleHelpers = context.bundleHelpers =
+		traceBundles(context.steal.loader);
 
-	var startup = stealStartup(steal, function(mainPromise){
-		var oldStartup = startup;
-		startup = mainPromise.then(function(modules){
-			// We were unable to reload the can modules which means
-			// there is some bug. But we can continue to render anyways.
-			if(isACanProject && !modules.can) {
-				return oldStartup;
-			}
-
-			return modules;
-		});
-	});
+	// Call steal.startup() and save the promise
+	var startup = new ReloadableStartup(context.steal);
 
 	var makeRenderStream = function(requestOrUrl){
-		var stream = new SafeStream(requestOrUrl);
-		Object.defineProperty(stream, "startup", {
-			get: function() { return startup; }
-		});
-		return stream;
+		return new SafeStream(requestOrUrl, startup, context);
 	};
 
 	// Expose the loader
-	makeRenderStream.loader = loader;
+	makeRenderStream.loader = context.steal.loader;
 
 	// Expose the startup promise
 	Object.defineProperty(makeRenderStream, "startupPromise", {
-		get: function() { return startup; }
+		get: function() { return startup.promise; }
 	});
 
 	return makeRenderStream;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,47 +1,40 @@
-var Readable = require("stream").Readable;
-var cleanupDocument = require("./cleanup");
 var configureLoader = require("./configure_loader");
-var Zone = require("can-zone");
 var makeContext = require("./context");
-var makeRender = require("./make_render");
-var addCookies = require( "./cookies" );
 var traceBundles = require("./bundles/index");
-var util = require("util");
 var ReloadableStartup = require("./reloadable-startup");
-
-var debug = require("./zones/debug");
-var timeout = require("can-zone/timeout");
-var TimeoutError = timeout.TimeoutError;
-var ssrGlobalsZone = require("./zones/globals");
-var canRouteDataZone = require("./zones/route_data");
-var xhrZone = require("./zones/xhr");
-var assetsZone = require("./zones/assets");
-var html5shivZone = require("./zones/html5");
-var responseZone = require("./zones/response");
 
 require("can-vdom");
 require("./polyfills/websocket");
 require("./polyfills/xhr");
 
-var SafeStream = require("./modes/safe");
+var strategies = {
+	safe: function(){
+		return require("./modes/safe");
+	}
+};
 
 global.doneSsr = {};
-
-var doctype = "<!DOCTYPE html>";
 
 module.exports = function(config, options){
 	var context = makeContext(config, options);
 
 	// Configure the loader so that the virtual DOM is loaded
 	configureLoader(context.steal, context.options);
-	var bundleHelpers = context.bundleHelpers =
-		traceBundles(context.steal.loader);
+	context.bundleHelpers = traceBundles(context.steal.loader);
 
 	// Call steal.startup() and save the promise
 	var startup = new ReloadableStartup(context.steal);
 
+	// Get the rendering strate
+	var getStrategy = strategies[context.options.strategy || "safe"];
+	if(!getStrategy) {
+		throw new Error("The rendering strategy " + context.options.strategy +
+				" is not supported.");
+	}
+	var SSRStream = getStrategy();
+
 	var makeRenderStream = function(requestOrUrl){
-		return new SafeStream(requestOrUrl, startup, context);
+		return new SSRStream(requestOrUrl, startup, context);
 	};
 
 	// Expose the loader

--- a/lib/modes/safe.js
+++ b/lib/modes/safe.js
@@ -39,10 +39,11 @@ SafeStream.prototype.render = function(){
 	var cfg = this.context.config;
 	var options = this.context.options;
 	var request = this.request;
-	var startup = this.startup.promise;
-	var steal = this.startup.steal;
+	var startup = this.startup;
+	var startupPromise = startup.promise;
+	var steal = startup.steal;
 
-	return startup.then(function(modules){
+	return startupPromise.then(function(modules){
 		var main = modules.main;
 		var can = modules.can;
 		var DOCUMENT = modules.DOCUMENT;

--- a/lib/modes/safe.js
+++ b/lib/modes/safe.js
@@ -18,6 +18,7 @@ SafeStream.prototype._read = function(){
 SafeStream.prototype.render = function(){
 	var stream = this;
 	var request = this.request;
+	var startup = this.startup;
 
 	return startup.then(function(modules){
 		var main = modules.main;
@@ -110,3 +111,5 @@ SSRStream.prototype.pipe = function(dest){
 	this.dests.push(dest);
 	return Readable.prototype.pipe.apply(this, arguments);
 };
+
+module.exports = SSRStream;

--- a/lib/modes/safe.js
+++ b/lib/modes/safe.js
@@ -1,10 +1,28 @@
+var addCookies = require( "../cookies" );
+var cleanupDocument = require("../cleanup");
+var makeRender = require("../make_render");
 var makeRequest = require("../util/make_request");
 var Readable = require("stream").Readable;
 var util = require("util");
+var Zone = require("can-zone");
 
-var SafeStream = function(requestOrUrl){
+var debug = require("../zones/debug");
+var timeout = require("can-zone/timeout");
+var TimeoutError = timeout.TimeoutError;
+var ssrGlobalsZone = require("../zones/globals");
+var canRouteDataZone = require("../zones/route_data");
+var xhrZone = require("../zones/xhr");
+var assetsZone = require("../zones/assets");
+var html5shivZone = require("../zones/html5");
+var responseZone = require("../zones/response");
+
+var doctype = "<!DOCTYPE html>";
+
+var SafeStream = function(requestOrUrl, startup, context){
 	Readable.call(this);
 	this.request = makeRequest(requestOrUrl);
+	this.startup = startup;
+	this.context = context;
 	this.dests = [];
 };
 
@@ -17,8 +35,12 @@ SafeStream.prototype._read = function(){
 
 SafeStream.prototype.render = function(){
 	var stream = this;
+	var bundleHelpers = this.context.bundleHelpers;
+	var cfg = this.context.config;
+	var options = this.context.options;
 	var request = this.request;
-	var startup = this.startup;
+	var startup = this.startup.promise;
+	var steal = this.startup.steal;
 
 	return startup.then(function(modules){
 		var main = modules.main;
@@ -27,8 +49,8 @@ SafeStream.prototype.render = function(){
 		var domMutate = modules.domMutate;
 
 		// Save whether this is a can project or not.
-		if(isACanProject === undefined) {
-			isACanProject = !!can;
+		if(startup.isACanProject === null) {
+			startup.isACanProject = !!can;
 		}
 
 		// Create the document
@@ -48,7 +70,7 @@ SafeStream.prototype.render = function(){
 		var render = makeRender(main, can);
 
 		var zonePlugins = [
-			ssrGlobalsZone(doc, request, loader, steal, modules),
+			ssrGlobalsZone(doc, request, steal, modules),
 			canRouteDataZone(can),
 			assetsZone(doc, bundleHelpers, can),
 			responseZone(stream)
@@ -77,7 +99,7 @@ SafeStream.prototype.render = function(){
 		return zone.run(function(){
 			render(request);
 
-			if(isACanProject && can.route) {
+			if(startup.isACanProject && can.route) {
 				zone.data.viewModel = can.route.data;
 			}
 		}).then(null, function(err){
@@ -95,7 +117,7 @@ SafeStream.prototype.render = function(){
 			var dt = cfg.doctype || doctype;
 			html = dt + "\n" + html;
 
-			//stream.push(html);
+			stream.push(html);
 			stream.push(null);
 		}, function(error){
 			stream.emit("error", error);
@@ -107,9 +129,9 @@ SafeStream.prototype.render = function(){
 	});
 };
 
-SSRStream.prototype.pipe = function(dest){
+SafeStream.prototype.pipe = function(dest){
 	this.dests.push(dest);
 	return Readable.prototype.pipe.apply(this, arguments);
 };
 
-module.exports = SSRStream;
+module.exports = SafeStream;

--- a/lib/modes/safe.js
+++ b/lib/modes/safe.js
@@ -1,0 +1,112 @@
+var makeRequest = require("../util/make_request");
+var Readable = require("stream").Readable;
+var util = require("util");
+
+var SafeStream = function(requestOrUrl){
+	Readable.call(this);
+	this.request = makeRequest(requestOrUrl);
+	this.dests = [];
+};
+
+util.inherits(SafeStream, Readable);
+
+SafeStream.prototype._read = function(){
+	if(this._renderPromise) { return; }
+	this._renderPromise = this.render();
+};
+
+SafeStream.prototype.render = function(){
+	var stream = this;
+	var request = this.request;
+
+	return startup.then(function(modules){
+		var main = modules.main;
+		var can = modules.can;
+		var DOCUMENT = modules.DOCUMENT;
+		var domMutate = modules.domMutate;
+
+		// Save whether this is a can project or not.
+		if(isACanProject === undefined) {
+			isACanProject = !!can;
+		}
+
+		// Create the document
+		var doc = new document.constructor();
+
+		addCookies(doc, request);
+
+		var serializeFromBody = !!(main.renderAsync ||
+								   main.serializeFromBody);
+		if(!serializeFromBody) {
+			doc.head = doc.createElement("head");
+			doc.documentElement.insertBefore(doc.head, doc.body);
+		}
+
+		// Create a renderer function that when calls will
+		// render into a virtual DOM.
+		var render = makeRender(main, can);
+
+		var zonePlugins = [
+			ssrGlobalsZone(doc, request, loader, steal, modules),
+			canRouteDataZone(can),
+			assetsZone(doc, bundleHelpers, can),
+			responseZone(stream)
+		];
+
+		if(typeof XMLHttpRequest !== "undefined") {
+			zonePlugins.push(xhrZone(options));
+		}
+
+		if(options.html5shiv) {
+			zonePlugins.push(html5shivZone(can));
+		}
+
+		var timeoutZone = timeout(options.timeout);
+		zonePlugins.push(timeoutZone);
+
+		if(options.debug) {
+			var debugZone = debug(doc, timeoutZone);
+			zonePlugins.push(debugZone);
+		}
+
+		var zone = new Zone({
+			plugins: zonePlugins
+		});
+
+		return zone.run(function(){
+			render(request);
+
+			if(isACanProject && can.route) {
+				zone.data.viewModel = can.route.data;
+			}
+		}).then(null, function(err){
+			if(!(err instanceof TimeoutError)) {
+				throw err;
+			}
+		}).then(function(data){
+			var html;
+			if(serializeFromBody) {
+				html = doc.body.innerHTML;
+			} else {
+				html = doc.documentElement.outerHTML;
+			}
+
+			var dt = cfg.doctype || doctype;
+			html = dt + "\n" + html;
+
+			//stream.push(html);
+			stream.push(null);
+		}, function(error){
+			stream.emit("error", error);
+		}).then(function(){
+			cleanupDocument(doc, DOCUMENT, domMutate);
+		});
+	}, function(error){
+		stream.emit("error", error);
+	});
+};
+
+SSRStream.prototype.pipe = function(dest){
+	this.dests.push(dest);
+	return Readable.prototype.pipe.apply(this, arguments);
+};

--- a/lib/reloadable-startup.js
+++ b/lib/reloadable-startup.js
@@ -13,7 +13,7 @@ function ReloadableStartup(steal) {
     this.isACanProject = null;
 
     var replaceStartup = function(mainPromise){
-		var oldPromise = this.startup;
+		var oldPromise = this.promise;
 		this.promise = mainPromise.then(function(modules){
 			// We were unable to reload the can modules which means
 			// there is some bug. But we can continue to render anyways.

--- a/lib/reloadable-startup.js
+++ b/lib/reloadable-startup.js
@@ -1,0 +1,31 @@
+var stealStartup = require("./startup");
+
+/*
+ * Provides a way to listen to reloads
+ * and replaces the previous steal.startup() promise
+ * with the replaced one.
+ **/
+
+function ReloadableStartup(steal) {
+    this.steal = steal;
+
+    // Initialize to null; we don't know if this is a can project yet
+    this.isACanProject = null;
+
+    var replaceStartup = function(mainPromise){
+		var oldPromise = this.startup;
+		this.promise = mainPromise.then(function(modules){
+			// We were unable to reload the can modules which means
+			// there is some bug. But we can continue to render anyways.
+			if(this.isACanProject && !modules.can) {
+				return oldPromise;
+			}
+
+			return modules;
+		}.bind(this));
+	}.bind(this);
+
+	this.promise = stealStartup(steal, replaceStartup);
+}
+
+module.exports = ReloadableStartup;

--- a/lib/util/make_request.js
+++ b/lib/util/make_request.js
@@ -1,0 +1,10 @@
+
+module.exports = function(requestOrUrl) {
+	if(typeof requestOrUrl === "string") {
+		return {
+			url: requestOrUrl
+		};
+	} else {
+		return requestOrUrl;
+	}
+};

--- a/lib/zones/globals.js
+++ b/lib/zones/globals.js
@@ -1,7 +1,8 @@
 var url = require("url");
 
-module.exports = function(document, request, loader, steal, modules){
+module.exports = function(document, request, steal, modules){
 	var DOCUMENT = modules.DOCUMENT || function(){};
+	var loader = steal.loader;
 
 	return function(data){
 		var location = url.parse(request.url, true);

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "can-util": "^3.5.1",
     "can-vdom": "^3.0.1",
     "can-zone": "^0.6.1",
+    "dom-patch": "^2.0.0-alpha.2",
     "lodash.defaults": "^4.0.1",
     "steal": "^1.0.6",
     "websocket": "^1.0.22",

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -70,7 +70,6 @@ describe("async rendering", function(){
 	it("sets a 404 status for bad routes", function(done){
 		var response = through(function(){
 			var statusCode = response.statusCode;
-			console.log("status is....", statusCode);
 			assert.equal(statusCode, 404, "Got a 404");
 			done();
 		});

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -70,6 +70,7 @@ describe("async rendering", function(){
 	it("sets a 404 status for bad routes", function(done){
 		var response = through(function(){
 			var statusCode = response.statusCode;
+			console.log("status is....", statusCode);
 			assert.equal(statusCode, 404, "Got a 404");
 			done();
 		});


### PR DESCRIPTION
This makes it so that done-ssr can support multiple rendering strategies. A rendering strategy is implemented as a Readable Stream.  The default rendering strategy is called "safe" (bikeshed on name).  This is how done-ssr currently works; using a Zone to track async stuff and only sending HTML once it is complete.

With this change we can start to implement other rendering strategies.  The first that I will take on is the incremental rendering strategy.