### PR TITLE
Fix case with an empty route

### DIFF
--- a/lib/make_render.js
+++ b/lib/make_render.js
@@ -44,11 +44,12 @@ function makeCreateState(main, can){
 
 		if(!attr.get(state, "statusCode") &&
 				!isEmptyObject(can.route.routes)) {
-			if(!params.route) {
+			// fix: support root-url (i.e '/') in production-mode
+			if(params.route || (params.route === "")) {
+				attr.set(state, "statusCode", 200);
+			} else {
 				attr.set(state, "statusCode", 404);
 				attr.set(state, "statusMessage", "Not found");
-			} else {
-				attr.set(state, "statusCode", 200);
 			}
 		}
 		return state;

--- a/lib/make_render.js
+++ b/lib/make_render.js
@@ -45,7 +45,7 @@ function makeCreateState(main, can){
 		if(!attr.get(state, "statusCode") &&
 				!isEmptyObject(can.route.routes)) {
 			// fix: support root-url (i.e '/') in production-mode
-			if(params.route || (params.route === "")) {
+			if(typeof params.route === "string") {
 				attr.set(state, "statusCode", 200);
 			} else {
 				attr.set(state, "statusCode", 404);

--- a/lib/zones/route_data.js
+++ b/lib/zones/route_data.js
@@ -32,11 +32,12 @@ module.exports = function(can){
 			if(!statusCode) {
 				if(hasRoutes()) {
 					var currentRoute = can.route.matched();
-					// If there is no current route it is likely a 404
-					if(!currentRoute) {
-						statusCode = 404;
-					} else {
+					// fix: support root-url (i.e '/') in develop-mode
+					if(currentRoute || (currentRoute === "")) {
 						statusCode = 200;
+					} else {
+						// If there is no current route it is likely a 404
+						statusCode = 404;
 					}
 				} else {
 					statusCode = 200;

--- a/test/tests/async/routes.js
+++ b/test/tests/async/routes.js
@@ -1,4 +1,5 @@
 var route = require("can-route");
 require("can-route-pushstate");
 
+route("", { page: "orders" });
 route("{page}", { page: "orders" });

--- a/test/tests/plain/main.js
+++ b/test/tests/plain/main.js
@@ -21,7 +21,7 @@ var pages = {
 export default function(request){
 	var props = route.deparam(location.pathname);
 	var state = new AppViewModel(props);
-	
+
 	route.data = state;
 
 	$(document.head).html(headTemplate(state));


### PR DESCRIPTION
This replaces https://github.com/donejs/done-ssr/pull/244, adds a test.

This fixes the case of empty routes:

```js
route("", { page: "home" });
```