### PR TITLE
Don't set the document.head

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,8 +101,8 @@ module.exports = function(cfg, options){
 			var serializeFromBody = !!(main.renderAsync ||
 									   main.serializeFromBody);
 			if(!serializeFromBody) {
-				doc.head = doc.createElement("head");
-				doc.documentElement.insertBefore(doc.head, doc.body);
+				var head = doc.createElement("head");
+				doc.documentElement.insertBefore(head, doc.body);
 			}
 
 			// Create a renderer function that when calls will


### PR DESCRIPTION
In can-simple-dom 1.0.9 document.head became a getter, so we shouldn't
be trying to set it. Fixes #257