### PR TITLE
Prevent errors within render() from causing wrong error to bubble out

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "can-util": "^3.5.1",
     "can-vdom": "^3.0.1",
-    "can-zone": "^0.6.1",
+    "can-zone": "^0.6.8",
     "lodash.defaults": "^4.0.1",
     "steal": "^1.0.6",
     "websocket": "^1.0.22",

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -76,4 +76,13 @@ describe("async rendering", function(){
 
 		this.render("/fake").pipe(response);
 	});
+
+	it.only("sets a 500 status when there are errors", function(done){
+		var response = through(function(){
+			console.log("WHAT:", response.statusCode);
+			done();
+		});
+
+		this.render("?showError=true").pipe(response);
+	});
 });

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -77,12 +77,17 @@ describe("async rendering", function(){
 		this.render("/fake").pipe(response);
 	});
 
-	it.only("sets a 500 status when there are errors", function(done){
+	it("sets a 500 status when there are errors", function(done){
 		var response = through(function(){
-			console.log("WHAT:", response.statusCode);
+			assert.ok(false, "Should not have gotten here");
 			done();
 		});
 
-		this.render("?showError=true").pipe(response);
+		var renderStream = this.render("?showError=true");
+		renderStream.pipe(response);
+		renderStream.on("error", function(err){
+			assert.ok(true, "Got an error");
+			done();
+		});
 	});
 });

--- a/test/tests/async/appstate.js
+++ b/test/tests/async/appstate.js
@@ -33,5 +33,8 @@ module.exports = Map.extend({
 				}, 50);
 			}
 		}
+	},
+	someError: function(){
+		throw new Error("This is an error.");
 	}
 });

--- a/test/tests/async/index.stache
+++ b/test/tests/async/index.stache
@@ -21,5 +21,9 @@
 		{{/eq}}
 
 		<div class="language">{{language}}</div>
+
+		{{#if showError}}
+			<span>{{someError}}</span>
+		{{/if}}
 	</body>
 </html>


### PR DESCRIPTION
Mostly this is just upgrade to can-zone 0.6.8. Fixes #264