### PR TITLE
Make incremental renderer wait for initial styles

### DIFF
--- a/lib/strategies/incremental/index.js
+++ b/lib/strategies/incremental/index.js
@@ -2,7 +2,7 @@ var fs = require("fs");
 var makeRequest = require("../../util/make_request");
 var patch = require("dom-patch");
 var Readable = require("stream").Readable;
-var renderApp = require("../../render_app");
+var renderApp = require("./render_app");
 var SafeStream = require("../safe");
 var useragent = require("useragent");
 var util = require("util");
@@ -44,9 +44,11 @@ IncrementalRenderingStream.prototype._read = function(){
 					ss.pipe(response);
 				});
 			} else {
-				var html = stream.render();
-				stream.push(html);
-				stream.push(null);
+				var promise = stream.render();
+				promise.then(function(html){
+					stream.push(html);
+					stream.push(null);
+				});
 			}
 		});
 		return;
@@ -75,15 +77,17 @@ IncrementalRenderingStream.prototype.render = function (){
 		instrStream.write(msg);
 	}
 
-	patch(doc, onChanges);
+	return render.initialStylesLoaded().then(function(){
+		patch(doc, onChanges);
 
-	// When the Zone is complete, stop listening for changes.
-	render.promise.then(function(){
-		patch.unbind(onChanges);
-		instrStream.end();
+		// When the Zone is complete, stop listening for changes.
+		render.promise.then(function(){
+			patch.unbind(onChanges);
+			instrStream.end();
+		});
+
+		return inject(doc.documentElement.outerHTML, instrUrl);
 	});
-
-	return inject(doc.documentElement.outerHTML, instrUrl);
 };
 
 IncrementalRenderingStream.prototype.pipe = function(dest){

--- a/lib/strategies/incremental/index.js
+++ b/lib/strategies/incremental/index.js
@@ -70,7 +70,7 @@ IncrementalRenderingStream.prototype.render = function (){
 		method: "GET",
 		request: { accept: "*/*" },
 		response: { "content-type": "text/plain" }
-	});
+});
 
 	function onChanges(changes){
 		var msg = JSON.stringify(changes);
@@ -82,6 +82,7 @@ IncrementalRenderingStream.prototype.render = function (){
 
 		// When the Zone is complete, stop listening for changes.
 		render.promise.then(function(){
+			patch.flush();
 			patch.unbind(onChanges);
 			instrStream.end();
 		});

--- a/lib/strategies/incremental/render_app.js
+++ b/lib/strategies/incremental/render_app.js
@@ -1,15 +1,15 @@
-var addCookies = require("./cookies");
-var makeRender = require("./make_render");
+var addCookies = require("../../cookies");
+var makeRender = require("../../make_render");
 var Zone = require("can-zone");
 
-var debug = require("./zones/debug");
+var debug = require("../../zones/debug");
 var timeout = require("can-zone/timeout");
-var ssrGlobalsZone = require("./zones/globals");
-var canRouteDataZone = require("./zones/route_data");
-var xhrZone = require("./zones/xhr");
-var assetsZone = require("./zones/assets");
-var html5shivZone = require("./zones/html5");
-var responseZone = require("./zones/response");
+var ssrGlobalsZone = require("../../zones/globals");
+var canRouteDataZone = require("../../zones/route_data");
+var xhrZone = require("../../zones/xhr");
+var incStylesZone = require("./styles_zone");
+var html5shivZone = require("../../zones/html5");
+var responseZone = require("../../zones/response");
 
 module.exports = function(stream, request, modules, context, plugins){
 	var startup = context.startup;
@@ -37,7 +37,7 @@ module.exports = function(stream, request, modules, context, plugins){
 	var zonePlugins = [
 		ssrGlobalsZone(doc, request, steal, modules),
 		canRouteDataZone(can),
-		assetsZone(doc, bundleHelpers, can),
+		incStylesZone(doc, bundleHelpers, can),
 		responseZone(stream)
 	].concat(plugins);
 
@@ -72,6 +72,9 @@ module.exports = function(stream, request, modules, context, plugins){
 	return {
 		zone: zone,
 		promise: promise,
-		document: doc
+		document: doc,
+		initialStylesLoaded: function(){
+			return zone.data.initialStylesLoaded;
+		}
 	};
 };

--- a/lib/strategies/incremental/styles_zone.js
+++ b/lib/strategies/incremental/styles_zone.js
@@ -1,0 +1,40 @@
+var assetsZone = require("../../zones/assets");
+var canData = require("can-util/dom/data/data");
+
+module.exports = function(doc, bundleHelpers, can){
+	return function(data){
+		var promises = [], initialRun = false;
+
+		// Keep track of can-import calls that happen during the initial render
+		var oldCanImport;
+		var canImport = function(el){
+			var res = oldCanImport.apply(this, arguments);
+			var promise = canData.get.call(el, "pageNormalizePromise");
+			promises.push(promise);
+			return res;
+		};
+
+		var renderStylesIntoDocument = function(){
+			data.applyPages();
+		};
+
+		return {
+			plugins: [assetsZone(doc, bundleHelpers, can)],
+
+			beforeTask: function(){
+				if(!initialRun) {
+					oldCanImport = can.view.callbacks._tags["can-import"];
+					can.view.callbacks._tags["can-import"] = canImport;
+				}
+			},
+			afterTask: function(){
+				if(!initialRun) {
+					initialRun = true;
+					can.view.callbacks._tags["can-import"] = oldCanImport;
+					data.initialStylesLoaded = Promise.all(promises)
+						.then(renderStylesIntoDocument);
+				}
+			}
+		};
+	};
+};

--- a/lib/zones/assets.js
+++ b/lib/zones/assets.js
@@ -2,22 +2,28 @@ var canImportZone = require("./can_import");
 
 module.exports = function(doc, bundleHelpers, can){
 	return function(data){
+		var inserted = new Set();
 		return {
 			plugins: [canImportZone(can)],
 
+			beforeRun: function(){
+				data.applyPages = function(){
+					var pages = data.pages || [];
+					applyPages(doc, bundleHelpers, pages, inserted);
+				};
+			},
+
 			ended: function(){
-				var pages = data.pages || [];
-				applyPages(doc, bundleHelpers, pages);
+				data.applyPages();
 			}
 		};
 	};
 };
 
-function applyPages(document, bundleHelpers, pages){
+function applyPages(document, bundleHelpers, pages, inserted){
 	var findBundle = bundleHelpers.findBundle;
 	var bundles = bundleHelpers.bundles;
 
-	var inserted = {};
 	var head = document.head;
 
 	pages.forEach(function(moduleName){
@@ -26,9 +32,9 @@ function applyPages(document, bundleHelpers, pages){
 		if(bundle) {
 			Object.keys(bundle).forEach(function(childName){
 				var asset = bundle[childName];
-				if(asset && !inserted[asset.id]) {
+				if(asset && !inserted.has(asset.id)) {
 
-					inserted[asset.id] = true;
+					inserted.add(asset.id);
 					var node = asset.value();
 					node.setAttribute("asset-id", asset.id);
 					head.insertBefore(node, head.lastChild);

--- a/lib/zones/can_import.js
+++ b/lib/zones/can_import.js
@@ -1,3 +1,5 @@
+var canData = require("can-util/dom/data/data");
+
 module.exports = function(can){
 	return function(data){
 		// If this is not a CanJS project
@@ -15,7 +17,7 @@ module.exports = function(can){
 			var isAPage = !!tagData.subtemplate;
 			var loader = doneSsr.loader;
 			var res = loader.normalize(moduleName, parentName);
-			Promise.resolve(res).then(function(name){
+			var pagePromise = Promise.resolve(res).then(function(name){
 				if(isAPage) {
 					loader.__ssrParentMap[name] = false;
 				}
@@ -25,6 +27,7 @@ module.exports = function(can){
 				}
 				pages.push(name);
 			});
+			canData.set.call(el, "pageNormalizePromise", pagePromise);
 
 			oldCanImport.apply(this, arguments);
 		};

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "can-util": "^3.5.1",
     "can-vdom": "^3.0.1",
     "can-zone": "^0.6.1",
-    "dom-patch": "^2.0.1",
+    "dom-patch": "^2.1.0",
     "lodash.defaults": "^4.0.1",
     "node-fetch": "^1.7.1",
     "node-web-streams": "^0.2.2",

--- a/test/incremental_test.js
+++ b/test/incremental_test.js
@@ -46,14 +46,14 @@ describe("Incremental rendering", function(){
 			});
 			response.writeHead = noop;
 			response.push = function(){
-				var count = 0;
+				var count = 0, ended = false;
 				return new Writable({
 					write(chunk, enc, next) {
 						var json = chunk.toString();
 						var instrs = JSON.parse(json);
 						result.instructions.push(instrs);
-
-						if(++count > 1) {
+						if(++count === 3 && !ended) {
+							ended = true;
 							done();
 						}
 						next();

--- a/test/tests/async/index.stache
+++ b/test/tests/async/index.stache
@@ -3,8 +3,9 @@
 		<title>test page</title>
 	</head>
 	<body>
-		<can-import from="async/routes"/>
+		<can-import from="async/routes" />
 		<can-import from="async/appstate" as="viewModel" />
+		<can-import from="async/styles.css" />
 
 		{{page}}
 

--- a/test/tests/async/styles.css
+++ b/test/tests/async/styles.css
@@ -1,0 +1,3 @@
+body {
+	background: blue;
+}


### PR DESCRIPTION
This makes it so that the initial renderer strategy waits for the
initial styles to load before sending the initial bit of HTML. Closes #285