### PR TITLE
Make a copy of process.env

### DIFF
--- a/lib/make_render.js
+++ b/lib/make_render.js
@@ -37,7 +37,7 @@ function makeCreateState(main, can){
 
 		var pathname = url.parse(request.url).href;
 		var params = assign(can.route.deparam(pathname), {
-			env: process.env,
+			env: Object.assign({}, process.env),
 			request: request
 		});
 

--- a/lib/strategies/incremental/index.js
+++ b/lib/strategies/incremental/index.js
@@ -11,6 +11,12 @@ var util = require("util");
 var clientScript = getClientScript();
 patch.collapseTextNodes = true;
 
+var patchTypes = ["attribute", "replace", "insert",
+	"remove", "text", "prop", "style"].reduce(truthyObject, {});
+
+// This is needed for now, need to figure out why
+patch(global.document, Function.prototype);
+
 var IncrementalRenderingStream = function(requestOrUrl, startup, context){
 	Readable.call(this);
 	this.request = makeRequest(requestOrUrl);
@@ -57,6 +63,7 @@ IncrementalRenderingStream.prototype.render = function (){
 	var request = this.request;
 	var response = this.dests[0];
 	
+	patch.flush();
 	var render = renderApp(this, request, this.modules, this.context, []);
 	var doc = render.document;
 
@@ -71,8 +78,15 @@ IncrementalRenderingStream.prototype.render = function (){
 });
 
 	function onChanges(changes){
-		var msg = JSON.stringify(changes);
-		instrStream.write(msg);
+		var instructions = changes.filter(function(change){
+			// Is this one of the changes that we care about.
+			return patchTypes[change.type];
+		});
+
+		if(instructions.length) {
+			var msg = JSON.stringify(instructions) + "\n";
+			instrStream.write(msg);
+		}
 	}
 
 	return render.initialStylesLoaded().then(function(){
@@ -126,4 +140,9 @@ function getClientScript() {
 	var debugMode = typeof process.env.DONE_SSR_DEBUG !== "undefined";
 	var clientPth = `${dir}/${basename}${debugMode ? "" : ".min"}.js`;
 	return fs.readFileSync(clientPth, "utf8");
+}
+
+function truthyObject(acc, key){
+	acc[key] = true;
+	return acc;
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "can-util": "^3.5.1",
     "can-vdom": "^3.0.1",
     "can-zone": "^0.6.1",
-    "dom-patch": "^2.1.0",
+    "dom-patch": "^2.1.1",
     "done-ssr-incremental-rendering-client": "^1.0.2",
     "lodash.defaults": "^4.0.1",
     "node-fetch": "^1.7.1",

--- a/test/incremental_test.js
+++ b/test/incremental_test.js
@@ -46,16 +46,12 @@ describe("Incremental rendering", function(){
 			});
 			response.writeHead = noop;
 			response.push = function(){
-				var count = 0, ended = false;
 				return new Writable({
 					write(chunk, enc, next) {
 						var json = chunk.toString();
 						var instrs = JSON.parse(json);
 						result.instructions.push(instrs);
-						if(++count === 3 && !ended) {
-							ended = true;
-							done();
-						}
+						done();
 						next();
 					}
 				});
@@ -65,9 +61,12 @@ describe("Incremental rendering", function(){
 		});
 
 		it("Sends the correct rendering instructions", function(){
-			var instr = this.result.instructions[0][0];
-			var route = instr.route;
-			assert.equal(route, "0.2.7");
+			var instr = this.result.instructions[0][1];
+			assert.equal(instr.route, "0.2.7");
+			
+			// Easier to test
+			var nodeAsJson = JSON.stringify(instr.node);
+			assert.ok(/ORDER-HISTORY/.test(nodeAsJson), "adds the order-history component");
 		});
 
 		it("Includes the styles as part of the initial HTML", function(){

--- a/test/tests/async/index.stache
+++ b/test/tests/async/index.stache
@@ -15,11 +15,11 @@
 					<order-history></order-history>
 				{{/isResolved}}
 			</can-import>
-
-			{{#if message}}
-				<div id="message">{{message}}</div>
-			{{/if}}
 		{{/eq}}
+
+		{{#if message}}
+			<div id="message">{{message}}</div>
+		{{/if}}
 
 		<div class="language">{{language}}</div>
 	</body>


### PR DESCRIPTION
Because process.env is an "exotic object" and not a regular object, it
can do weird things when passed across contexts (in the require("vm")
sense), such as throw on some Symbol access. What these eyes
have seen. Closes #293