### PR TITLE
Push style mutations out as styles are registered

### DIFF
--- a/lib/strategies/incremental/styles_zone.js
+++ b/lib/strategies/incremental/styles_zone.js
@@ -15,7 +15,12 @@ module.exports = function(doc, bundleHelpers, can){
 			return res;
 		};
 
+		// Keep track of when initial styles have been inserted. These should
+		// be part of the returned HTML. Any subsequent style insertions will
+		// be sent out immediately after they happen.
+		var initialStyles = false;
 		var renderStylesIntoDocument = function(){
+			initialStyles = true;
 			data.applyPages();
 		};
 
@@ -37,6 +42,8 @@ module.exports = function(doc, bundleHelpers, can){
 
 					data.initialStylesLoaded = Promise.all(promises)
 						.then(renderStylesIntoDocument);
+				} else if(initialStyles) {
+					renderStylesIntoDocument();
 				}
 			}
 		};

--- a/test/inc_helpers.js
+++ b/test/inc_helpers.js
@@ -1,0 +1,64 @@
+// Incremental rendering test helpers
+
+var helpers = require("./helpers");
+var through = require("through2");
+var noop = Function.prototype;
+var Writable = require("stream").Writable;
+
+function Deferred() {
+	this.promise = new Promise(function(resolve, reject){
+		this.resolve = resolve;
+		this.reject = reject;
+	}.bind(this));
+}
+
+function emptyWritable() {
+	return new Writable({write(c,e,next){next();}});
+}
+
+exports.mock = function(url, expectedPushes){
+	var dfd = new Deferred();
+
+	var result = {
+		html: null,
+		instructions: []
+	};
+
+	var request = {
+		url: "/orders",
+		headers: {
+			"user-agent": helpers.ua.chrome
+		}
+	};
+
+	var response = through(function(buffer, enc, done){
+		result.html = buffer.toString();
+	});
+	response.writeHead = noop;
+
+	function instructions() {
+		return new Writable({
+			write(chunk, enc, next) {
+				var json = chunk.toString();
+				var instrs = JSON.parse(json);
+				result.instructions.push(instrs);
+				next();
+			}
+		});
+	}
+
+	var pushes = expectedPushes;
+	response.push = function(url){
+		pushes--;
+		if(pushes === 0) {
+			setTimeout(dfd.resolve, 10);
+		}
+		if(/donessr_instructions/.test(url)) {
+			return instructions();
+		} else if(url === "foo://bar") {
+			return emptyWritable();
+		}
+	};
+
+	return { request, response, result, complete: dfd.promise };
+};

--- a/test/incremental_prog_test.js
+++ b/test/incremental_prog_test.js
@@ -30,40 +30,25 @@ describe("Incremental rendering", function(){
 		global.XMLHttpRequest = this.oldXHR;
 	});
 
-	describe("A basic async app", function(){
+	describe("A progressively loaded page", function(){
 		before(function(done){
 			var {
 				request,
 				response,
 				result,
 				complete
-			} = incHelpers.mock("/", 2);
+			} = incHelpers.mock("/orders", 2);
 
 			this.result = result;
 			this.render(request).pipe(response);
 
-			// Complete is a promise that resolves when rendering is done
 			complete.then(done);
 		});
 
-		it("Sends the correct rendering instructions", function(){
-			var instr = this.result.instructions[0][1];
-			assert.equal(instr.route, "0.2.7");
-			
-			// Easier to test
-			var nodeAsJson = JSON.stringify(instr.node);
-			assert.ok(/ORDER-HISTORY/.test(nodeAsJson), "adds the order-history component");
-		});
-
-		it("Includes the styles as part of the initial HTML", function(){
-			var dom = helpers.dom(this.result.html);
-			// The script is the first element of the dom
-			var doc = dom.nextSibling;
-			var style = helpers.find(doc, function(el){
-				return el.nodeName === "STYLE";
-			});
-
-			assert.ok(style, "Some styles were included");
+		it("Pushed a mutation to insert styles", function(){
+			var instr = this.result.instructions[0][0];
+			assert.equal(instr.type, "insert", "Inserting an element");
+			assert.equal(instr.node[3], "STYLE", "Inserting a style tag");
 		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -23,5 +23,6 @@ mochas([
 	"cache-normalize_test.js",
 	"leak_test.js",
 	"incremental_test.js",
-	"incremental_plain_test.js"
+	"incremental_plain_test.js",
+	"incremental_prog_test.js"
 ], __dirname);


### PR DESCRIPTION
Any time styles are registered, go ahead and push out the mutation
(incremental rendering instruction) for that style. Keeps a flag so that
we know when the initial styles are rendered (which will be part of the
		initial HTML), and any time thereafter, go ahead and push out
any styles that we have, via an instruction.

This prevents FOUC. Fixes #312