### PR TITLE
Delay when mutations start to be recorded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+package-lock.json
 node_modules/
 test/tests/node_modules/
 doc/

--- a/zones/mutations.js
+++ b/zones/mutations.js
@@ -35,7 +35,8 @@ module.exports = function(response, url){
 			created() {
 				assert(data.document, "The mutations zone requires a document.");
 				data.mutations = mutationStream;
-
+			},
+			afterRun: function(){
 				// If another plugin has a Promise for delaying mutations,
 				// wait for that to resolve.
 				if(isPromise(data.startMutations)) {
@@ -43,8 +44,7 @@ module.exports = function(response, url){
 				} else {
 					startListeningToMutations();
 				}
-			},
-			afterRun: function(){
+
 				data.html = data.document.documentElement.outerHTML;
 			},
 			afterStealMain: function(){

--- a/zones/push-mutations.js
+++ b/zones/push-mutations.js
@@ -44,7 +44,6 @@ module.exports = function(response, url){
 			plugins: [mutations(response)],
 
 			created: function(){
-				debugger;
 				injectScript(data.document);
 
 				instrStream = response.push(url, {

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -64,7 +64,7 @@ describe("SSR Zones - Basics", function(){
 
 		it("Contains mutations", function(){
 			var pushes = this.response.data.pushes;
-			var liMutation = JSON.parse(pushes[0][2][1].toString());
+			var liMutation = JSON.parse(pushes[0][2][0].toString());
 
 			assert.equal(liMutation[0].type, "insert", "Inserting a li");
 			assert.equal(liMutation[0].node[3], "LI", "Inserting a li");


### PR DESCRIPTION
Delay when mutations are listened to, until afterRun. This allows for
sending initial HTML after run which does contain the reattachment
script, preventing it to be sent as a mutation command.