### PR TITLE
Make sure steal-css appends to the global document

### DIFF
--- a/test/progressive_test.js
+++ b/test/progressive_test.js
@@ -36,6 +36,8 @@ describe("Server-Side Rendering Basics", function(){
 	it("works with progressively loaded bundles", function(done){
 		var stream = this.render("/orders");
 
+		stream.on("error", done);
+
 		var response = through(function(buffer){
 			var html = buffer.toString();
 			var node = helpers.dom(html);

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ mochas([
 	"../zones/zones-mutations-test.js",
 	"../zones/zones-steal-test.js",
 	"../zones/zones-canjs-test.js",
-	//"../zones/zones-donejs-test.js",
+	"../zones/zones-donejs-test.js",
 	"async_test.js",
 	"cookie_test.js",
 	"leakscope_test.js",

--- a/test/tests/progressive/index.stache
+++ b/test/tests/progressive/index.stache
@@ -31,7 +31,7 @@
 			<div>Showing: {{request.url}}</div>
 		{{/if}}
 
-		<div id="location">{{location}}</div>
-		<div id="doc-location">{{docLocation}}</div>
+		<div id="location">{{location()}}</div>
+		<div id="doc-location">{{docLocation()}}</div>
 	</body>
 </html>

--- a/zones/can-simple-dom.js
+++ b/zones/can-simple-dom.js
@@ -1,7 +1,10 @@
 var makeWindow = require("can-vdom/make-window/make-window");
+var makeDocument = require("can-vdom/make-document/make-document");
 var once = require("once");
 var url = require("url");
 var zoneRegister = require("can-zone/register");
+
+var globalDocument = makeDocument();
 
 module.exports = function(request){
 	return function(data){
@@ -25,6 +28,11 @@ module.exports = function(request){
 				data.document = window.document;
 				data.request = request;
 				registerNode(window);
+			},
+			beforeTask: function(){
+				if(global.doneSsr) {
+					global.doneSsr.globalDocument = globalDocument;
+				}
 			},
 			ended: function(){
 				data.html = data.document.documentElement.outerHTML;

--- a/zones/donejs/global-document.js
+++ b/zones/donejs/global-document.js
@@ -1,0 +1,12 @@
+var once = require("once");
+
+// This is a legacy thing, for steal-css
+var doneSsrGlobal = Object.create(null);
+
+module.exports = function(){
+	return {
+		globals: {
+			doneSsr: doneSsrGlobal
+		}
+	};
+};


### PR DESCRIPTION
A big change in the refactoring of done-ssr into zones is that now steal
loads during the first request; it doesn't load *prior* to the first
request. That means that side-effects of loading steal, in the case of
steal-css is that it appends styles/links to the document, are going to
be part of the user's rendered result.

This is undesirable. Lucky steal-css checks for a
`doneSsr.globalDocument` and will append to that instead. This change
makes it so that this document is created and used.

Closes #386