### PR TITLE
Use node traversal to find the modal for debug info

### DIFF
--- a/test/timeout_test.js
+++ b/test/timeout_test.js
@@ -29,7 +29,7 @@ describe("Timeouts", function(){
 			Promise.resolve().then(function(){
 				var html = buffer.toString();
 				var node = helpers.dom(html);
-				
+
 				var result = node.getElementById("result").innerHTML;
 
 				assert.equal(result, "failed", "Timed out");

--- a/zones/debug/index.js
+++ b/zones/debug/index.js
@@ -15,7 +15,16 @@ module.exports = function(/*doc, */timeoutZone){
 				div.setAttribute("id", "done-ssr-debug");
 				div.innerHTML = modal;
 
-				var modalBody = div.getElementById("ssr-modal-body");
+				var modalBody;
+				var n = div.firstChild.lastChild;
+				while(n) {
+					if(n.getAttribute && n.getAttribute("id") === "ssr-modal-body") {
+						modalBody = n;
+						break;
+					}
+					n = n.previousSibling;
+				}
+
 				info.forEach(function(d){
 					var div = doc.createElement("div");
 					div.innerHTML = infoh.replace("{{title}}", d.task);


### PR DESCRIPTION
Previously this code used getElementById on an HTMLElement, which is an
API supported by can-simple-dom, but not a standard dom API. This means
this code breaks with can-zone-jsdom.

The new approach uses lastChild/previousSibling combo to find the node.
Fixes #381