### PR TITLE
Add the data-incrementally-rendered attribute to <html>

### DIFF
--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -69,6 +69,7 @@ module.exports = function(url){
 			`;
 			appendToHead(doc, closeScript);
 			doc.body.setAttribute("style", "visibility: hidden;");
+			doc.documentElement.setAttribute("data-incrementally-rendered", "");
 		}
 
 		return {

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -57,7 +57,7 @@ describe("SSR Zones - Incremental Rendering", function(){
 
 		it("Contains the correct initial HTML", function(){
 			var dom = helpers.dom(this.zone.data.initialHTML);
-			assert.equal(dom.getAttribute("data-incrementally-rendered", ""),
+			assert.equal(dom.getAttribute("data-incrementally-rendered"), "",
 				"contains the flag that incrementally rendering is used");
 
 			var ul = helpers.find(dom, node => node.nodeName === "UL");

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -57,8 +57,10 @@ describe("SSR Zones - Incremental Rendering", function(){
 
 		it("Contains the correct initial HTML", function(){
 			var dom = helpers.dom(this.zone.data.initialHTML);
-			var ul = helpers.find(dom, node => node.nodeName === "UL");
+			assert.equal(dom.getAttribute("data-incrementally-rendered", ""),
+				"contains the flag that incrementally rendering is used");
 
+			var ul = helpers.find(dom, node => node.nodeName === "UL");
 			assert.ok(!ul.firstChild, "There are no child LIs yet");
 		});
 


### PR DESCRIPTION
This adds the data-incrementally-rendered attribute to the
documentElement when using `zones/push-mutations`. This lets libraries
know that incremental rendering is enabled, in case they want to use a
different rendering strategy because of this.

This is needed for https://github.com/donejs/autorender/issues/85