### PR TITLE
Document each of the zones

### DIFF
--- a/docs/zones/can-simple-dom.md
+++ b/docs/zones/can-simple-dom.md
@@ -1,0 +1,29 @@
+Provides a simple DOM interface for applications. [can-simple-dom](https://github.com/canjs/can-simple-dom) doesn't attempt to be fully standards complaint, but rather to provide the basic interfaces that most applications need. If you need a more complaint DOM, use [can-zone-jsdom](https://github.com/canjs/can-zone-jsdom).
+
+```js
+const Zone = require("can-zone");
+const dom = require("done-ssr/zones/can-simple-dom");
+
+require("http").createServer(async function(request, response){
+
+	let zone = new Zone([
+		dom(request)
+	]);
+
+	function app() {
+		let div = document.createElement("div");
+		div.textContent = "Hello world!";
+		document.body.appendChild(div);
+	}
+
+	let {html} = await zone.run();
+	response.end(html);
+
+}).listen(8080);
+```
+
+# Signature
+
+## dom(request)
+
+The *can-simple-dom* zone requests a request object. It uses this to set up a few things, including the `window.location` and `navigator.language`.

--- a/docs/zones/canjs.md
+++ b/docs/zones/canjs.md
@@ -1,0 +1,27 @@
+The *done-ssr/zones/canjs* zone is used for integration with [canjs](https://canjs.com/) applications, mostly involving `can.route`.
+
+```js
+const Zone = require("can-zone");
+const canjs = require("done-ssr/zones/canjs");
+
+require("http").createServer(function(request, response){
+
+	new Zone([
+		canjs(response)
+	])
+
+}).listen(8080);
+```
+
+This zone provides the following features:
+
+* [can-globals/location/location](https://canjs.com/doc/can-globals/location/location.html) will be set to the correct location throughout the zone's lifetime.
+* [can-globals/document/document](https://canjs.com/doc/can-globals/document/document.html) will be set to the correct location throughout the zone's lifetime.
+* can-route's [route.data](https://canjs.com/doc/can-route.data.html) property will be set throughout the zone's lifetime (this allows multiple requests to be processed at the same time).
+* Additionally, if the *route.data* property contains a __statusCode__ value, that value will be set on the `response.statusCode`.
+
+# Signature
+
+## canjs(response)
+
+In order to set the status code, this zone needs the http(s) *response* object.

--- a/docs/zones/cookies.md
+++ b/docs/zones/cookies.md
@@ -1,0 +1,19 @@
+The *done-ssr/zones/cookies* zone will set the `document.cookie` property. It must be used after a DOM zone.
+
+```js
+const Zone = require("can-zone");
+const dom = require("done-ssr/zones/can-simple-dom");
+const cookies = require("done-ssr/zones/cookies");
+
+require("http").createServer(function(request, response){
+
+	new Zone([
+		dom(request),
+
+		cookies(request, response)
+	])
+
+}).listen(8080);
+```
+
+The cookies zone will extract the cookies from the request and place them on the `document.cookie`, and then later on the `response.cookie`.

--- a/docs/zones/debug.md
+++ b/docs/zones/debug.md
@@ -1,0 +1,38 @@
+The *done-ssr/zones/debug* zone is used to debug applications when they timeout. This zone expects either a *can-zone/timeout* zone, or a Number of milliseconds before timing out (in which case it will create a *can-zone/timeout* itself).
+
+```js
+const Zone = require("can-zone");
+const debug = require("done-ssr/zones/debug");
+
+require("http").createServer(function(request, response){
+	new Zone([
+		debug(5000);
+	]);
+}).listen(8080);
+```
+
+# Signature
+
+## debug(timeout)
+
+Creates a debug zone using the provided *timeout*, in milliseconds:
+
+```js
+debug(5000)
+```
+
+## debug(timeoutZone)
+
+Creates a debug zone, using the provided *can-zone/timeout* zone.
+
+```js
+const timeout = require("can-zone/timeout");
+
+...
+
+let timeoutZone timeout(5000);
+
+new Zone([
+	debug(timeoutZone)
+])
+```

--- a/docs/zones/donejs.md
+++ b/docs/zones/donejs.md
@@ -1,0 +1,22 @@
+The *done-ssr/zones/donejs* zone is used to set up *done-ssr/zones/steal* and *done-ssr/zones/canjs*. This prevents users from needing to configure each of those zones individually.
+
+```js
+const Zone = require("can-zone");
+const donejs = require("done-ssr/zones/donejs");
+
+require("http").createServer(function(request, response){
+
+	new Zone([
+		donejs({
+			config: __dirname + "/package.json!npm"
+		}, response)
+	]);
+
+}).listen(8080);
+```
+
+# Signature
+
+## donejs(stealConfig, response)
+
+Since this zone mainly just combines the steal and canjs zones, it needs each of those zones arguments.

--- a/docs/zones/mutations.md
+++ b/docs/zones/mutations.md
@@ -1,0 +1,68 @@
+The *done-ssr/zones/mutations* zone creates the `data.mutations` stream, for which serialized DOM mutations are written. Usually you will want to use *done-ssr/zones/push-mutations* rather than this zone.
+
+Use this zone if you want to handle the mutations yourself (pushing them to the browser and then applying the patches in the browser).
+
+```js
+const Zone = require("can-zone");
+const mutations = require("done-ssr/zones/mutations");
+
+require("donejs-spdy").createServer({
+	key: ...,
+	cert: ...
+}, async function(request, response){
+
+	let zone = new Zone([
+		mutations()
+	]);
+
+	let runPromise = zone.run();
+
+	zone.data.mutations.on('data', function(chunk){
+		// Chunk is a string of DOM mutations
+	});
+
+	let stream = response.push("/mutation-stream", {
+		status: 200,
+		method: "GET",
+		request: { accept: "*/*" },
+		response: {
+			"content-type": "text/plain"
+		}
+	});
+
+	// This pushes mutations into this PUSH promise stream
+	// it is up to you on how to handle this in the browser.
+	zone.data.mutations.pipe(stream);
+
+	response.end(zone.data.html);
+
+}).listen(8081);
+```
+
+# Signature
+
+## mutations()
+
+This zone takes no arguments.
+
+# Data properties
+
+These are the can-zone *data properties* that the mutations stream either creates or consumes.
+
+### Input
+
+These are data properties that *done-ssr/zones/mutations* will use, if present.
+
+#### zone.data.startMutations
+
+A Promise, used to delay when the zone starts listening to DOM mutations. You might use this if you want to modify the document and do not want these modifications to be part of the mutation stream.
+
+### Output
+
+These are data properties the zone creates.
+
+### zone.data.mutations
+
+A Node.js [readable stream](https://nodejs.org/api/stream.html#stream_readable_streams) of DOM mutations. Pipe this into a writable stream.
+
+##

--- a/docs/zones/push-fetch.md
+++ b/docs/zones/push-fetch.md
@@ -1,0 +1,46 @@
+*done-ssr/zones/push-fetch*, when used on an HTTP/2 server, will initiate a PUSH promise for any URLs when using the [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API.
+
+```js
+const Zone = require("can-zone");
+const pushFetch = require("done-ssr/zones/push-xhr");
+const requests = require("done-ssr/zones/requests");
+const app = require("./app");
+
+require("donejs-spdy").createServer({
+	key: ...,
+	cert: ...
+}, function(request, response){
+
+	new Zone([
+		requests(request),
+		pushFetch(response)
+	])
+	.run(app);
+
+}).listen(8081);
+```
+
+Where *app.js* looks like:
+
+```js
+module.exports = function(){
+	let ul = document.createElement('ul');
+	document.body.appendChild(ul);
+
+	// In the browser this URL will be PUSHed
+	fetch('/api/todos').then(res => res.json())
+	.then(todos => {
+		todos.forEach(todo => {
+			let li = document.createElement('li');
+			li.textContent = todo;
+			ul.appendChild(li);
+		});
+	});
+};
+```
+
+# Signature
+
+## pushFetch(response)
+
+*done-ssr/zones/push-fetch* expects a http(s) response object, which it uses to initiate the PUSH promise.

--- a/docs/zones/push-images.md
+++ b/docs/zones/push-images.md
@@ -1,0 +1,39 @@
+*done-ssr/zones/push-images* is a zone that is used to initiate PUSH promises on images created using `new Image()` or `document.createElement('img')` APIs. Pushing these images will result in faster load times for your page.
+
+```js
+const Zone = require("can-zone");
+const dom = require("done-ssr/zones/can-simple-dom");
+const pushImages = require("done-ssr/zones/push-images");
+const app = require("./app");
+
+require("donejs-spdy", {
+	cert: ...,
+	key: ...
+}, function(request, response){
+
+	new Zone([
+		dom(request),
+		pushImages(response)
+	])
+	.run(app);
+
+}).listen(8081);
+```
+
+where *app.js* looks like:
+
+```js
+module.exports = function(){
+	let img = document.createElement("img");
+	img.src = "/images/cat.png";
+	document.body.appendChild(img);
+};
+```
+
+Will result in `/images/cat.png` being PUSHed.
+
+# Signature
+
+## pushImages(response)
+
+*done-ssr/zones/push-images* expects an http(s) response object, which it uses to initiate the PUSH promise.

--- a/docs/zones/push-mutations.md
+++ b/docs/zones/push-mutations.md
@@ -1,0 +1,34 @@
+The *done-ssr/zones/push-mutations* zone is used for incremental rendering. It initiates a PUSH promise on the HTTP/2 connection, and pushes out DOM mutations that will be handled by a small client-side script that is injected into the page.
+
+```js
+const Zone = require("can-zone");
+const dom = require("done-ssr/zones/can-simple-dom");
+const pushMutations = require("done-ssr/zones/push-mutations");
+const app = require("./app");
+
+require("donejs-spdy", {
+	key: ...,
+	cert: ...
+}, function(request, response){
+
+	let zone = new Zone([
+		dom(request),
+
+		pushMutations(response/* , url */)
+	]);
+
+	zone.run(app);
+	response.end(zone.data.html);
+
+}).listen(8081);
+```
+
+This will establish a PUSH promise for DOM mutations. These mutations will be streamed to the browser and applied in patches by a small client-side script.
+
+# Signature
+
+## pushMutations(response, url)
+
+This zone expects a *response* object, which is used to initiate the PUSH promise.
+
+Optionally you can provide a *url* string, the URL that will be used for the mutations stream. By default pushMutations will create a URL that is unlikely to conflict with one your app uses; in the form of `"/_donessr_instructions/" + Date.now()`

--- a/docs/zones/push-xhr.md
+++ b/docs/zones/push-xhr.md
@@ -1,0 +1,43 @@
+*done-ssr/zones/push-xhr*, when used within an HTTP/2 server, will establish a PUSH promise for all requests that are made with the `XMLHttpRequest` API.
+
+```js
+const Zone = require("can-zone");
+const pushXHR = require("done-ssr/zones/push-xhr");
+const requests = require("done-ssr/zones/requests");
+const app = require("./app");
+
+require("donejs-spdy").createServer({
+	key: ...,
+	cert: ...
+}, function(request, response){
+
+	new Zone([
+		requests(request),
+		pushXHR(response)
+	])
+	.run(app);
+
+}).listen(8081);
+```
+
+Where *app.js* looks like:
+
+```js
+module.exports = function(){
+	let xhr = new XMLHttpRequest();
+	xhr.open('/api/todos');
+	xhr.onload = function(){
+		let todos = JSON.parse(xhr.responseText);
+		// todo do something with the todos
+	};
+	xhr.send();
+};
+```
+
+This will establish a PUSH promise for `/api/todos`. If the browser requests this URL (for example if you are running the same code in the browser), it will already be available to it in the PUSH cache.
+
+# Signature
+
+## pushXHR(response)
+
+push-xhr needs the server's *response* object in order to set up the PUSH promise.

--- a/docs/zones/requests.md
+++ b/docs/zones/requests.md
@@ -1,0 +1,23 @@
+Enables polyfills for the XMLHttpRequest, fetch, and WebSocket APIs. Enables routing server-relative URLs such as `/api/todos` to resolve as `http://example.com/api/todos`.
+
+```js
+var requests = require("done-ssr/zones/requests");
+var Zone = require("can-zone");
+
+require("http").createServer(function(request, response){
+
+	new Zone([
+		requests(request)
+	])
+
+}).listen(8080);
+```
+
+# Signature
+
+## requests(request, options)
+
+Takes an [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) (commonly called the __request__ object) and optionally an __options__ object with the shape of:
+
+* __options.auth.cookie__: Specifies a cookie to include with API requests.
+* __optiosn.auth.domains__: Specifies an Array of domains for which the *options.auth.cookie** will be set for.

--- a/docs/zones/steal.md
+++ b/docs/zones/steal.md
@@ -1,0 +1,43 @@
+Enables loading an application that depends on the steal module loader.
+
+```js
+var Zone = require("can-zone");
+var steal = require("done-ssr/zones/steal");
+
+require("http").createServer(function(request, response){
+	new Zone([
+		steal({
+			config: __dirname + "/package.json!npm",
+			// Other steal configuration here
+		})
+	])
+}).listen(8080);
+```
+
+Your main can be defined one of two ways, it can either export a function that will be re-executed on each request, or the body of the main itself will re-excute. Export a function if you need to set up side-effects that happen only once.
+
+__main.js__
+
+```js
+const Framework = require("my-framework");
+
+module.exports = function(){
+	let app = new Framework();
+	app.render(document.body);
+}
+```
+
+*or*
+
+```js
+const Framework = require("my-framework");
+
+let app = new Framework();
+app.render(document.body);
+```
+
+# Signature
+
+## steal(stealConfig)
+
+Takes a steal [configuration object](https://stealjs.com/docs/config.config.html), like those you provide to steal-tools or done-ssr.

--- a/zones.md
+++ b/zones.md
@@ -68,13 +68,13 @@ module.exports = function(){
 
 done-ssr provides the following (expanding) list of zones:
 
-* __done-ssr/zones/requests__: Provides XMLHttpRequest and fetch polyfills. Overrides requests so that they are made to the server handling the node.js Request. This zone collects the following:
+* __[done-ssr/zones/requests](https://github.com/donejs/done-ssr/blob/master/docs/zones/requests.md)__: Provides XMLHttpRequest and fetch polyfills. Overrides requests so that they are made to the server handling the node.js Request. This zone collects the following:
   * __done-ssr/zones/xhr__: Overrides XMLHttpRequest, rerouting requests to the Node.js server running.
   * __done-ssr-zones/fetch__: Overrides fetch, rerouting requests to the Node.js server running.
 
-* __done-ssr/zones/push-fetch__: When using an HTTP/2 server like [spdy](https://github.com/spdy-http2/node-spdy) (support for http2 in Node 8 coming soon), will PUSH any fetches made to the server. This will speed up any repetitive requests that exist in the client.
-* __done-ssr/zones/push-xhr__: When using an HTTP/2 server like [spdy](https://github.com/spdy-http2/node-spdy) (support for http2 in Node 8 coming soon), will PUSH any XHR requests made to the server. This will speed up any repetitive requests that exist in the client.
-* __done-ssr/zones/push-images__: Like the 2 above zones, but will PUSH images. So if your code adds images to the DOM like:
+* __[done-ssr/zones/push-fetch](https://github.com/donejs/done-ssr/blob/master/docs/zones/push-fetch.md)__: When using an HTTP/2 server like [spdy](https://github.com/spdy-http2/node-spdy) (support for http2 in Node 8 coming soon), will PUSH any fetches made to the server. This will speed up any repetitive requests that exist in the client.
+* __[done-ssr/zones/push-xhr](https://github.com/donejs/done-ssr/blob/master/docs/zones/ush-xhr.md)__: When using an HTTP/2 server like [spdy](https://github.com/spdy-http2/node-spdy) (support for http2 in Node 8 coming soon), will PUSH any XHR requests made to the server. This will speed up any repetitive requests that exist in the client.
+* __[done-ssr/zones/push-images](https://github.com/donejs/done-ssr/blob/master/docs/zones/push-images.md)__: Like the 2 above zones, but will PUSH images. So if your code adds images to the DOM like:
 
 ```js
 var img = document.createElement("img");
@@ -91,7 +91,7 @@ var zone = new Zone([
 	pushImages(response)
 ])
 ```
-* __done-ssr/zones/push-mutations__: This is used internally by done-ssr's incremental rendering strategy. Use this if you want to skip waiting on the Zone to complete, but rather want to stream out mutations to the client as they happen.
+* __[done-ssr/zones/push-mutations](https://github.com/donejs/done-ssr/blob/master/docs/zones/requests.md)__: This is used internally by done-ssr's incremental rendering strategy. Use this if you want to skip waiting on the Zone to complete, but rather want to stream out mutations to the client as they happen.
 
 This Zone (like the other PUSH zones) requires an HTTP/2 server.
 
@@ -117,5 +117,7 @@ require("spdy").createServer(options, function(request, response){
 });
 ```
 
-* __can-zone-jsdom__: Uses [jsdom](https://www.npmjs.com/package/jsdom) to provide a global document. This should usually be the first plugin listed, as it is used by other zones like `done-ssr/zones/push-images`.
-* __done-ssr/zones/can-simple-dom__: Use [can-simple-dom](https://github.com/canjs/can-simple-dom) to provide a global `document` and `window`. This is like jsdom but is not spec compatible. It provides only a minimal DOM needed for most applications (and is the default DOM used by done-ssr).
+* __[can-zone-jsdom](https://github.com/canjs/can-zone-jsdom)__: Uses [jsdom](https://www.npmjs.com/package/jsdom) to provide a global document. This should usually be the first plugin listed, as it is used by other zones like `done-ssr/zones/push-images`.
+* __[done-ssr/zones/can-simple-dom](https://github.com/donejs/done-ssr/blob/master/docs/zones/can-simple-dom.md)__: Use [can-simple-dom](https://github.com/canjs/can-simple-dom) to provide a global `document` and `window`. This is like jsdom but is not spec compatible. It provides only a minimal DOM needed for most applications (and is the default DOM used by done-ssr).
+
+* __done-ssr/zones/canjs](https://github.com/donejs/done-ssr/blob/master/docs/zones/requests.md)__: Makes sure globals within a canjs application are configured for each zone task, and sets the `response.statusCode` when `route.data.statusCode` is a number.

--- a/zones/mutations.js
+++ b/zones/mutations.js
@@ -7,7 +7,7 @@ domPatch.collapseTextNodes = true;
 var patchTypes = ["attribute", "replace", "insert",
 	"remove", "text", "prop", "style"].reduce(truthyObject, {});
 
-module.exports = function(response, url){
+module.exports = function(){
 	return function(data){
 		var mutationStream = new Readable({
 			read() {

--- a/zones/push-images.js
+++ b/zones/push-images.js
@@ -2,7 +2,6 @@
 module.exports = function(response, root){
 	root = root || process.cwd();
 
-	var domPatch = require("dom-patch");
 	var fs = require("fs");
 	var mime = require("mime-types");
 	var url = require("url");
@@ -33,10 +32,12 @@ module.exports = function(response, root){
 			}
 		}
 
-		function onChanges(changes) {
+		function pushAddedImages() {
 			for(let img of images) {
-				images.delete(img);
-				pushImage(img);
+				if(document.documentElement.contains(img)) {
+					images.delete(img);
+					pushImage(img);
+				}
 			}
 		}
 
@@ -51,7 +52,6 @@ module.exports = function(response, root){
 		return {
 			created: function(){
 				document = data.document;
-				domPatch(document, onChanges);
 			},
 			beforeTask: function(){
 				oldCreateElement = document.createElement;
@@ -59,9 +59,7 @@ module.exports = function(response, root){
 			},
 			afterTask: function(){
 				document.createElement = oldCreateElement;
-			},
-			ended: function(){
-				domPatch.unbind(document, onChanges);
+				pushAddedImages();
 			}
 		};
 	};


### PR DESCRIPTION
This adds documentation, under `docs/zones`, for each of the zone
plugins. It provides usage examples and signatures.