### PR TITLE
Apply can-import override after steal.done

### DIFF
--- a/zones/steal/styles/can-import.js
+++ b/zones/steal/styles/can-import.js
@@ -26,17 +26,22 @@ module.exports = function(data){
 		oldCanImport.apply(this, arguments);
 	};
 
+	function maybeApplyOverride() {
+		if(can) {
+			oldCanImport = can.view.callbacks._tags["can-import"];
+			if(oldCanImport) {
+				can.view.callbacks._tags["can-import"] = canImport;
+			}
+		}
+	}
+
 	return {
 		afterStealDone: function(){
 			can = data.modules.can;
+			maybeApplyOverride();
 		},
 		beforeTask: function(){
-			if(can) {
-				oldCanImport = can.view.callbacks._tags["can-import"];
-				if(oldCanImport) {
-					can.view.callbacks._tags["can-import"] = canImport;
-				}
-			}
+			maybeApplyOverride();
 		},
 		afterTask: function(){
 			if(can && oldCanImport) {

--- a/zones/zones-donejs-test.js
+++ b/zones/zones-donejs-test.js
@@ -34,7 +34,7 @@ describe("SSR Zones - DoneJS application", function(){
 	this.timeout(10000);
 
 	before(function(){
-		return spinUpServer(() => {
+		function runRequest() {
 			var request = new Request("/orders");
 			var response = this.response = new Response();
 
@@ -53,6 +53,12 @@ describe("SSR Zones - DoneJS application", function(){
 			});
 
 			return zone.run();
+		}
+
+		return spinUpServer(() => {
+			return runRequest.call(this).then(() => {
+				return runRequest.call(this);
+			});
 		});
 	});
 
@@ -76,5 +82,13 @@ describe("SSR Zones - DoneJS application", function(){
 
 		assert.equal(ct, "content-type: application/json",
 					 "Header was added");
+	});
+
+	it("Includes the right number of styles", function(){
+		assert(this.zone.data.html);
+		var node = helpers.dom(this.zone.data.html);
+
+		var styles = node.getElementsByTagName("style");
+		assert.equal(styles.length, 2, "2 styles are included");
 	});
 });


### PR DESCRIPTION
This ensures that the override is attached when render() is called.
Closes #416