### PR TITLE
Use can-globals/document/ and URL constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 test/tests/node_modules/
 doc/
 .idea/
+package-lock.json

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,6 +1,6 @@
 exports.modules = {
 	"can": "can-util/namespace",
-	"DOCUMENT": "can-util/dom/document/document",
+	"DOCUMENT": "can-globals/document/document",
 	"domMutate": "can-util/dom/mutate/mutate",
 	"LOCATION": "can-globals/location/location"
 };

--- a/lib/util/make_request.js
+++ b/lib/util/make_request.js
@@ -2,7 +2,9 @@
 module.exports = function(requestOrUrl) {
 	if(typeof requestOrUrl === "string") {
 		return {
-			url: requestOrUrl
+			url: requestOrUrl,
+			connection: {},
+			headers: {host:"localhost"}
 		};
 	} else {
 		return requestOrUrl;

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "can-zone": "^0.6.11",
     "dom-patch": "^2.1.1",
     "done-ssr-incremental-rendering-client": "^2.0.1",
+    "full-url": "^1.0.0",
     "is-promise": "^2.1.0",
     "lodash.defaults": "^4.0.1",
     "mime-types": "^2.1.17",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "text-encoding": "^0.6.4",
     "useragent": "^2.1.13",
     "websocket": "^1.0.22",
+    "whatwg-url": "^6.3.0",
     "xmlhttprequest2": "^1.0.0"
   },
   "greenkeeper": {

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -63,7 +63,9 @@ describe("async rendering", function(){
 	it("request language is used", function(done){
 		var request = {
 			url: "/",
+			connection: {},
 			headers: {
+				"host": "localhost",
 				"accept-language": "en-US"
 			}
 		};

--- a/test/auth-cookie-failed-domain_test.js
+++ b/test/auth-cookie-failed-domain_test.js
@@ -48,7 +48,9 @@ describe("auth cookies - failed domain", function() {
 	it("works", function(done) {
 		var stream = render({
 			url: '/',
+			connection: {},
 			headers: {
+				host: "localhost",
 				cookie: "feathers-jwt=foobar;"
 			}
 		});

--- a/test/auth-cookie_test.js
+++ b/test/auth-cookie_test.js
@@ -49,7 +49,9 @@ describe("auth cookies", function() {
 	it("works", function(done) {
 		var stream = render({
 			url: '/',
+			connection: {},
 			headers: {
+				host: "localhost",
 				cookie: "feathers-jwt=foobar;"
 			}
 		});

--- a/test/cookie_test.js
+++ b/test/cookie_test.js
@@ -44,7 +44,9 @@ describe("cookie async rendering", function() {
 		var stream = render({
 			//mocked up req object
 			url: "/",
+			connection: {},
 			headers: {
+				host: "localhost",
 				cookie: "willitcookie=letsfindout"
 			}
 		});

--- a/test/inc_helpers.js
+++ b/test/inc_helpers.js
@@ -26,7 +26,9 @@ exports.mock = function(url, expectedPushes){
 
 	var request = {
 		url: "/orders",
+		connection: {},
 		headers: {
+			"host": "localhost",
 			"user-agent": helpers.ua.chrome
 		}
 	};

--- a/test/incremental_plain_test.js
+++ b/test/incremental_plain_test.js
@@ -23,7 +23,7 @@ describe("Incremental rendering - plain JS", function(){
 		});
 	});
 
-	describe("A basic asyc app", function(){
+	describe("A basic async app", function(){
 		before(function(done){
 			var result = this.result = {
 				html: null,
@@ -32,7 +32,9 @@ describe("Incremental rendering - plain JS", function(){
 
 			var request = {
 				url: "/",
+				connection: {},
 				headers: {
+					host: "localhost",
 					"user-agent": helpers.ua.chrome
 				}
 			};

--- a/test/progressive_test.js
+++ b/test/progressive_test.js
@@ -17,19 +17,20 @@ describe("Server-Side Rendering Basics", function(){
 
 	it("basics works", function(done){
 		this.render("/").pipe(through(function(buffer){
-			var html = buffer.toString();
-			var node = helpers.dom(html);
+			Promise.resolve().then(function(){
+				var html = buffer.toString();
+				var node = helpers.dom(html);
 
-			var home = node.getElementById("home");
-			assert.ok(home, "Found the 'home' element");
+				var home = node.getElementById("home");
+				assert.ok(home, "Found the 'home' element");
 
-			var location = node.getElementById("location");
-			assert.equal(location.innerHTML, "/", "Got the window.location");
+				var location = node.getElementById("location");
+				assert.equal(location.innerHTML, "/", "Got the window.location");
 
-			var docLocation = node.getElementById("doc-location");
-			assert.equal(docLocation.innerHTML, "/", "Got the document.location");
-
-			done();
+				var docLocation = node.getElementById("doc-location");
+				assert.equal(docLocation.innerHTML, "/", "Got the document.location");
+			})
+			.then(done, done);
 		}));
 	});
 
@@ -38,8 +39,7 @@ describe("Server-Side Rendering Basics", function(){
 
 		stream.on("error", done);
 
-		var response = through(function(buffer){
-			var html = buffer.toString();
+		function check(html) {
 			var node = helpers.dom(html);
 
 			var found = {};
@@ -58,8 +58,12 @@ describe("Server-Side Rendering Basics", function(){
 				return el.getAttribute && el.getAttribute("id") === "totals";
 			});
 			assert.ok(totalsEl, "an element that was conditionally added in the 'inserted' event is rendered");
+		}
 
-			done();
+		var response = through(function(buffer){
+			Promise.resolve()
+			.then(check.bind(null, buffer.toString()))
+			.then(done, done);
 		});
 
 		stream.pipe(response);

--- a/test/tests/progressive/appstate.js
+++ b/test/tests/progressive/appstate.js
@@ -5,9 +5,9 @@ module.exports = Map.extend({
 		throw Error('Something went wrong');
 	},
 	location: function(){
-		return location.href;
+		return location.pathname;
 	},
 	docLocation: function(){
-		return document.location.href;
+		return document.location.pathname;
 	}
 });

--- a/test/tests/progressive/orders/orders.stache
+++ b/test/tests/progressive/orders/orders.stache
@@ -1,6 +1,6 @@
 <div id="orders">
 {{#each orders}}
-	<div>order {{%index}}</div>
+	<div>order {{scope.index}}</div>
 {{/each}}
 </div>
 

--- a/test/timeout_test.js
+++ b/test/timeout_test.js
@@ -5,7 +5,7 @@ var path = require("path");
 var through = require("through2");
 
 describe("Timeouts", function(){
-	this.timeout(10000);
+	this.timeout(30000);
 
 	before(function(done){
 		this.render = ssr({
@@ -20,11 +20,11 @@ describe("Timeouts", function(){
 		this.render("/fast").pipe(through(function(){
 			setTimeout(function(){
 				done();
-			}, 2000);
+			}, 10000);
 		}));
 	});
 
-	it.only("App times out after the specified time", function(done){
+	it("App times out after the specified time", function(done){
 		this.render("/slow").pipe(through(function(buffer){
 			Promise.resolve().then(function(){
 				var html = buffer.toString();

--- a/zones/can-simple-dom.js
+++ b/zones/can-simple-dom.js
@@ -1,7 +1,8 @@
+var fullUrl = require("full-url");
 var makeWindow = require("can-vdom/make-window/make-window");
 var makeDocument = require("can-vdom/make-document/make-document");
 var once = require("once");
-var url = require("url");
+var URL = require("url").URL;
 var zoneRegister = require("can-zone/register");
 
 var globalDocument = makeDocument();
@@ -12,7 +13,7 @@ module.exports = function(request){
 		var window = makeWindow({});
 		window.window = Object.assign({}, global, window);
 		window.location = window.document.location = window.window.location =
-		 url.parse(request.url, true);
+			new URL(fullUrl(request));
 		if(!window.location.protocol) {
 			window.location.protocol = "http:";
 		}

--- a/zones/can-simple-dom.js
+++ b/zones/can-simple-dom.js
@@ -2,7 +2,7 @@ var fullUrl = require("full-url");
 var makeWindow = require("can-vdom/make-window/make-window");
 var makeDocument = require("can-vdom/make-document/make-document");
 var once = require("once");
-var URL = require("url").URL;
+var URL = (require("url").URL || require("whatwg-url").URL);
 var zoneRegister = require("can-zone/register");
 
 var globalDocument = makeDocument();

--- a/zones/test-helpers.js
+++ b/zones/test-helpers.js
@@ -16,6 +16,8 @@ exports.Request = class extends http.IncomingMessage {
 		super();
 		this.url = url || "/";
 		this.protocol = "http";
+		this.connection = {};
+		this.headers = {host:"localhost"};
 		this.get = name => "localhost:8070";
 	}
 };


### PR DESCRIPTION
This is two fixes that fix the tests:

1. Using can-globals/document/document instead of
can-util/dom/document/document. For some reason the wrong result of
getDocument() was returning when using the latter. Rather than
investigate, just don't going to use the deprecated module any more.
2. Use the URL constructor to make the `location` object, since that
will be the same as the real `location` object. For example,
	 `location.search` will be an empty string when there is no search,
	 rather than null like was working before.