### PR TITLE
The `window` should be the global object.

### DIFF
--- a/zones/can-simple-dom.js
+++ b/zones/can-simple-dom.js
@@ -11,7 +11,7 @@ module.exports = function(request){
 	return function(data){
 		// Create the document
 		var window = makeWindow({});
-		window.window = Object.assign({}, global, window);
+		window.window = global;
 		window.location = window.document.location = window.window.location =
 			new URL(fullUrl(request));
 		if(!window.location.protocol) {

--- a/zones/tests/basics/main.js
+++ b/zones/tests/basics/main.js
@@ -29,5 +29,13 @@ module.exports = function(){
 	};
 	xhr.send();
 
+	// Verify that the `window` is the global object.
+	var realGlobal = (function(){ return this; })();
+	var areTheSame = realGlobal === window;
+	var globalDiv = document.createElement("div");
+	globalDiv.setAttribute("id", "the-global");
+	globalDiv.appendChild(document.createTextNode(areTheSame.toString()));
+	main.appendChild(globalDiv);
+
 	document.body.appendChild(main);
 };

--- a/zones/zones-basics-test.js
+++ b/zones/zones-basics-test.js
@@ -70,6 +70,10 @@ describe("SSR Zones - Basics", function(){
 			var cart = helpers.find(dom, node => node.getAttribute &&
 				node.getAttribute("id") === "cart");
 			assert.equal(cart.firstChild.nodeValue, "Count: 22", "XHR works");
+
+			var globalDiv = helpers.find(dom, node => node.getAttribute &&
+				node.getAttribute("id") === "the-global");
+			assert.equal(globalDiv.firstChild.nodeValue, "true", "The window is the global object");
 		});
 
 		it("Data from the fetch requests was pushed", function(){


### PR DESCRIPTION
This fixes #434. The `window` object is the Node `global`, so any state
on the global is available everywhere.