### PR TITLE
Make sure the IR iframe is not removed by done-autorender

### DIFF
--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -37,6 +37,7 @@ module.exports = function(url){
 
 		var iframe = document.createElement("iframe");
 		iframe.setAttribute("id", "donessr-iframe");
+		iframe.setAttribute("data-keep", "");
 		iframe.setAttribute("srcdoc", clone.outerHTML);
 		iframe.setAttribute("style", "border:0;position:fixed;top:0;left:0;right:0;bottom:0;width:100%;height:100%;visibility:visible;");
 		return iframe;

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -60,6 +60,10 @@ describe("SSR Zones - Incremental Rendering", function(){
 			assert.equal(dom.getAttribute("data-incrementally-rendered"), "",
 				"contains the flag that incrementally rendering is used");
 
+			var iframe = helpers.find(dom, node => node.nodeName === "IFRAME");
+			assert.equal(iframe.getAttribute("data-keep"), "",
+				"the iframe contains the 'keep' attribute to prevent it from being removed");
+
 			var ul = helpers.find(dom, node => node.nodeName === "UL");
 			assert.ok(!ul.firstChild, "There are no child LIs yet");
 		});


### PR DESCRIPTION
This adds the new `data-keep` attribute, preventing done-autorender from
removing the IR iframe before it is ready to be removed. Closes #486