### PR TITLE
Ensure the reattachment script's parent is the <head>

### DIFF
--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -12,7 +12,22 @@ module.exports = function(url){
 		} else {
 			document.head.appendChild(element);
 		}
-	};
+	}
+
+	function firstOfKind(root, nodeName) {
+		if (root == null) {
+			return null;
+		}
+
+		var node = root.firstChild;
+		while (node) {
+			if (node.nodeName === nodeName) {
+				return node;
+			}
+			node = node.nextSibling;
+		}
+		return null;
+	}
 
 	function makeIframe(document) {
 		var clone = document.documentElement.cloneNode(true);
@@ -25,7 +40,8 @@ module.exports = function(url){
 			}
 			el.setAttribute("data-noop", "");
 		});
-		var fakeDoc = { head: clone.firstChild };
+		
+		var fakeDoc = { head: firstOfKind(clone, "HEAD") };
 
 		// iframe placeholder
 		appendToHead(fakeDoc, document.createComment("iframe placeholder"));

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -111,6 +111,20 @@ describe("SSR Zones - Incremental Rendering with DoneJS", function(){
 		});
 	});
 
+	it("reattachment script is within the <head>", function(){
+		var dom = helpers.dom(this.zone.data.initialHTML);
+		var iframe = helpers.find(dom, node => node.nodeName === "IFRAME");
+
+		var html = helpers.decodeSrcDoc(iframe);
+		var idom = helpers.dom(html);
+
+		var reattach = helpers.find(idom, node => node.nodeType === 1 &&
+			node.hasAttribute("data-streamurl"));
+		var parent = reattach.parentNode;
+
+		assert.equal(parent.nodeName, "HEAD", "within the head");
+	});
+
 	it("iframe overlay contains styles", function(){
 		var dom = helpers.dom(this.zone.data.initialHTML);
 		var iframe = helpers.find(dom, node => node.nodeName === "IFRAME");


### PR DESCRIPTION
This ensures that the reattachment script (contained with the iframe) is
within the `<head>`. This is necessary so that the server DOM and the
iframe's DOM match. Otherwise the mutation commands would be off.

This change is necessary because most index.stache files contain a
TextNode beneath the document element.

Fixes #485