### PR TITLE
Handle error scenarios

### DIFF
--- a/lib/reloadable-startup.js
+++ b/lib/reloadable-startup.js
@@ -8,22 +8,16 @@ var stealStartup = require("./startup");
 
 function ReloadableStartup(steal) {
     this.steal = steal;
+	this.error = null;
 
-    // Initialize to null; we don't know if this is a can project yet
-    this.isACanProject = null;
-
-    var replaceStartup = function(mainPromise){
-		var oldPromise = this.promise;
-		this.promise = mainPromise.then(function(modules){
-			// We were unable to reload the can modules which means
-			// there is some bug. But we can continue to render anyways.
-			if(this.isACanProject && !modules.can) {
-				return oldPromise;
-			}
-
-			return modules;
-		}.bind(this));
-	}.bind(this);
+    var replaceStartup = (err, mainPromise) => {
+		if(err) {
+			this.error = err;
+		} else {
+			this.error = null;
+			this.promise = mainPromise;
+		}
+	};
 
 	this.promise = stealStartup(steal, replaceStartup);
 }

--- a/lib/ssr-stream.js
+++ b/lib/ssr-stream.js
@@ -60,6 +60,10 @@ SafeStream.prototype.render = function(){
 		zones.push(pushXHR(response));
 	}
 
+	if(this.options.zones) {
+		this.options.zones.forEach(zone => zones.push(zone));
+	}
+
 	// Make sure the `ready` process is caught, to prevent unhandledRejection
 	zones.push({
 		created: function(){

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -26,12 +26,17 @@ module.exports = function(steal, callback){
 		if(loader.liveReloadInstalled) {
 			var importOpts = {name: "@ssr"};
 			loader.import("live-reload", importOpts).then(function(reload){
-				reload(function(){
-					callback(
-						loader.import(loader.main)
-							.then(getMainModule)
-							.then(extractModules)
-					);
+				reload(function(err){
+					if(err) {
+						callback(err);
+					} else {
+						callback(null,
+							loader.import(loader.main)
+								.then(getMainModule)
+								.then(extractModules)
+						);
+					}
+
 				});
 			});
 		}

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "mime-types": "^2.1.17",
     "node-fetch": "^2.0.0",
     "once": "^1.4.0",
-    "steal": "^1.8.0",
+    "steal": "^1.9.0",
     "text-encoding": "^0.6.4",
     "useragent": "^2.1.13",
     "websocket": "^1.0.22",

--- a/test/error_handling_test.js
+++ b/test/error_handling_test.js
@@ -1,0 +1,99 @@
+var ssr = require("../lib/");
+var assert = require("assert");
+var path = require("path");
+var through = require("through2");
+
+describe("Handling errors during app lifecycle", function(){
+	this.timeout(10000);
+
+	var reloader;
+	var sources = {
+		"async/helpers": "module.exports = {};"
+	};
+
+	function reloadableFile(data) {
+		function fetchOverride(fetch) {
+			return function(load){
+				if(sources[load.name]) {
+					return Promise.resolve(sources[load.name]);
+				}
+				return fetch.apply(this, arguments);
+			};
+		}
+
+		return {
+			beforeStealStartup: function(){
+				var loader = data.steal.loader;
+				loader.fetch = fetchOverride(loader.fetch);
+
+				// Load live-reload so we can use it
+				this.waitFor(loader.import("live-reload").then(function(mod){
+					reloader = mod;
+				}));
+			}
+		};
+	}
+
+	before(function(){
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "async/index.stache!done-autorender",
+			configDependencies: ["live-reload"]
+		}, {
+			zones: [reloadableFile]
+		});
+	});
+
+	afterEach(function(){
+		sources["async/helpers"] = "module.exports = {};";
+	});
+
+	it("An error that occurs on live-reload is forwarded as an error", function(done){
+		var render = this.render;
+		render("/home").pipe(through(function(){
+
+			// App has loaded successfully, now cause an error
+			sources["async/helpers"] = "module.exports = {}; \n something 'syntax'";
+			reloader("async/helpers").then(function(){
+				var renderStream = render("/home");
+				renderStream.pipe(through(Function.prototype));
+				renderStream.on("error", function(err){
+					try {
+						assert.ok(err instanceof SyntaxError);
+					} catch(e) {
+						assert.ok(false, e);
+					} finally {
+						done();
+					}
+				});
+			});
+		}));
+	});
+
+	it.only("After an error occurs, fixing the error restores rendering", function(done){
+		var render = this.render;
+		render("/home").pipe(through(function(){
+			// App has loaded successfully, now cause an error
+			sources["async/helpers"] = "module.exports = {}; \n something 'syntax'";
+			reloader("async/helpers").then(function(){
+				var renderStream = render("/home");
+				renderStream.pipe(through(Function.prototype));
+				renderStream.on("error", function(err){
+					sources["async/helpers"] = "module.exports = {};";
+					reloader("async/helpers").then(function(){
+						var renderStream = render("/home");
+						renderStream.pipe(through(function(buffer){
+							var html = buffer.toString();
+							assert.ok(/hello async/.test(html), "returned the right html");
+							done();
+						}));
+						renderStream.on("error", function(){
+							assert.ok(false, "Got an error after fixing it");
+							done();
+						});
+					});
+				});
+			});
+		}));
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -26,5 +26,6 @@ mochas([
 	//"leak_test.js",
 	"incremental_test.js",
 	"incremental_plain_test.js",
-	"incremental_prog_test.js"
+	"incremental_prog_test.js",
+	"error_handling_test.js"
 ], __dirname);

--- a/test/tests/async/appstate.js
+++ b/test/tests/async/appstate.js
@@ -1,4 +1,5 @@
 var DefineMap = require("can-define/map/map");
+require("./helpers");
 
 module.exports = DefineMap.extend({
 	page: {

--- a/test/tests/async/helpers.js
+++ b/test/tests/async/helpers.js
@@ -1,0 +1,2 @@
+// This module only exists as something to mess with.
+module.exports = {};


### PR DESCRIPTION
This fixes the handling of 2 error scenarios:

1. Server starts cleanly and then a file changes producing an error.
From this point forward done-ssr will emit this error message until it
is fixed.

2. Server starts cleanly and then a file changes producing an error. The
file is changed again, resolving the error. From this point forward
done-ssr will resume rendering.

Closes #498