### PR TITLE
Prevent done-autorender from removing the debug modal

### DIFF
--- a/test/timeout_test.js
+++ b/test/timeout_test.js
@@ -61,6 +61,10 @@ describe("Timeouts", function(){
 			assert.ok(/setTimeout/.test(html),
 					  "Includes the task name that failed");
 
+			var node = helpers.dom(html);
+			var debug = node.getElementById("done-ssr-debug");
+			assert.equal(debug.getAttribute("data-keep"), "", "This attribute was added");
+
 			done();
 		}));
 	});

--- a/zones/debug/index.js
+++ b/zones/debug/index.js
@@ -13,6 +13,7 @@ module.exports = function(/*doc, */timeoutZone){
 
 				var div = doc.createElement("div");
 				div.setAttribute("id", "done-ssr-debug");
+				div.setAttribute("data-keep", "");
 				div.innerHTML = modal;
 
 				var modalBody;


### PR DESCRIPTION
This adds the `data-keep` attribute to the root debug node. This
prevents done-autorender from removing the element. Closes #505