### PR TITLE
Support fetch() response.ok

### DIFF
--- a/zones/requests/fetch.js
+++ b/zones/requests/fetch.js
@@ -32,7 +32,7 @@ module.exports = function(request){
 		}, options);
 
 		return nodeFetch(url, options).then(function(resp){
-			var response = Object.assign({}, resp);
+			var response = Object.create(resp);
 
 			// Convert the Node.js Readable stream to a WHATWG stream.
 			response._readableBody = resp.body;

--- a/zones/tests/basics/main.js
+++ b/zones/tests/basics/main.js
@@ -4,11 +4,19 @@ module.exports = function(){
 	var ul = document.createElement("ul");
 	main.appendChild(ul);
 
+	var statusSpan = document.createElement("span");
+	statusSpan.className = "status";
+	main.appendChild(statusSpan);
+
 	var img = document.createElement("img");
 	img.src = "/images/cat.png";
 	main.appendChild(img);
 
-	fetch("/api/todos").then(res => res.json()).then(todos => {
+	fetch("/api/todos").then(res => {
+		statusSpan.appendChild(document.createTextNode(res.ok ? "OK" : "BAD"));
+
+		return res.json();
+	}).then(todos => {
 		todos.forEach(todo => {
 			var li = document.createElement("li");
 			li.appendChild(document.createTextNode(todo));

--- a/zones/zones-basics-test.js
+++ b/zones/zones-basics-test.js
@@ -74,6 +74,9 @@ describe("SSR Zones - Basics", function(){
 			var globalDiv = helpers.find(dom, node => node.getAttribute &&
 				node.getAttribute("id") === "the-global");
 			assert.equal(globalDiv.firstChild.nodeValue, "true", "The window is the global object");
+
+			var statusSpan = helpers.find(dom, node => node.className === "status");
+			assert.equal(statusSpan.textContent, "OK", "Supports response.ok");
 		});
 
 		it("Data from the fetch requests was pushed", function(){

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -77,8 +77,8 @@ describe("SSR Zones - Incremental Rendering", function(){
 			var pushes = this.response.data.pushes;
 			var liMutation = JSON.parse(pushes[0][2][0].toString());
 
-			assert.equal(liMutation[0].type, "insert", "Inserting a li");
-			assert.equal(liMutation[0].node[3], "LI", "Inserting a li");
+			assert.equal(liMutation[1].type, "insert", "Inserting a li");
+			assert.equal(liMutation[1].node[3], "LI", "Inserting a li");
 		});
 	});
 });


### PR DESCRIPTION
The fetch API has a `response.ok` property that signifies a 20x
response.

This is supported by node-fetch. However we were making a copy of the
`response` object, and since `ok` is implemented as a non-enumerable
getter, our response object didn't contain it. The fix is to instead use
`Object.create()` to create a new object that extends from node-fetch's
response, and therefore inheriting it's prototype chain.

Fixes #509