### PR TITLE
Add a test for script injection vulnerability.

### DIFF
--- a/test/async_test.js
+++ b/test/async_test.js
@@ -60,6 +60,9 @@ describe("async rendering", function(){
 
 				assert.equal(ct, "content-type: application/json",
 							 "Header was added");
+
+				var scriptInjected = message.getAttribute("class");
+				assert.equal(scriptInjected, "&#x3E;&#x3C;/div&#x3E;&#x3C;script&#x3E;alert(&#x27;hi&#x27;)&#x3C;/script&#x3E;");
 			})
 			.then(done, done);
 		}));

--- a/test/tests/async/orders/orders.js
+++ b/test/tests/async/orders/orders.js
@@ -26,6 +26,12 @@ var ViewModel = DefineMap.extend({
 		get: function(last, resolve){
 			this.ordersPromise.then(resolve);
 		}
+	},
+
+	ordersClass: {
+		get: function() {
+			return "></div><script>alert('hi')</script>";
+		}
 	}
 });
 

--- a/test/tests/async/orders/orders.stache
+++ b/test/tests/async/orders/orders.stache
@@ -1,4 +1,4 @@
-<div id="orders">
+<div id="orders" class="{{ordersClass}}">
 {{#orders}}
 	<div>order {{scope.index}}</div>
 {{/orders}}


### PR DESCRIPTION
React had a vulnerability to script inject by providing an attribute
name that contains malicious code. Since DoneJS doesn't allow dynamic
attribute names this vulnerability isn't possible.

Adding a test anyways.