### PR TITLE
Clean up memory correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "uglify-js": "^3.3.19"
   },
   "dependencies": {
-    "can-dom-data-state": "^1.0.1",
-    "can-dom-mutate": "^1.0.2",
+    "can-dom-data-state": "^1.0.2",
+    "can-dom-mutate": "^1.2.1",
     "can-namespace": "^1.0.0",
     "can-reflect": "^1.11.0",
     "can-util": "^3.10.10",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "he": "^1.1.1",
     "jquery": "2.x - 3.x",
     "jshint": "^2.8.0",
-    "leakage": "0.3.0-beta",
+    "leakage": "0.4.0",
     "nock": "^9.0.11",
     "spawn-mochas": "^1.1.0",
     "steal-stache": "^4.0.0",

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -14,9 +14,10 @@ describe("async rendering", function(){
 		});
 
 		helpers.createServer(8070, function(req, res){
+			var data;
 			switch(req.url) {
 				case "/bar":
-					var data = [ { "a": "a" }, { "b": "b" } ];
+					data = [ { "a": "a" }, { "b": "b" } ];
 					break;
 				default:
 					throw new Error("No route for " + req.url);

--- a/test/auth-cookie-failed-domain_test.js
+++ b/test/auth-cookie-failed-domain_test.js
@@ -24,10 +24,11 @@ describe("auth cookies - failed domain", function() {
 		});
 
 		helpers.createServer(8070, function(req, res){
+			var data;
 			authHeader = req.headers.authorization;
 			switch(req.url) {
 				case "/api/list":
-					var data = [1,2,3,4,5];
+					data = [1,2,3,4,5];
 					break;
 				default:
 					throw new Error("No route for " + req.url);

--- a/test/auth-cookie_test.js
+++ b/test/auth-cookie_test.js
@@ -25,10 +25,11 @@ describe("auth cookies", function() {
 		});
 
 		helpers.createServer(8070, function(req, res){
+			var data;
 			authHeader = req.headers.authorization;
 			switch(req.url) {
 				case "/api/list":
-					var data = [1,2,3,4,5];
+					data = [1,2,3,4,5];
 					break;
 				default:
 					throw new Error("No route for " + req.url);

--- a/test/incremental_prog_test.js
+++ b/test/incremental_prog_test.js
@@ -9,9 +9,10 @@ describe("Incremental rendering", function(){
 
 	before(function(done){
 		helpers.createServer(8070, function(req, res){
+			var data;
 			switch(req.url) {
 				case "/bar":
-					var data = [ { "a": "a" }, { "b": "b" } ];
+					data = [ { "a": "a" }, { "b": "b" } ];
 					break;
 				default:
 					throw new Error("No route for " + req.url);

--- a/test/incremental_test.js
+++ b/test/incremental_test.js
@@ -12,9 +12,10 @@ describe("Incremental rendering", function(){
 
 	before(function(done){
 		helpers.createServer(8070, function(req, res){
+			var data;
 			switch(req.url) {
 				case "/bar":
-					var data = [ { "a": "a" }, { "b": "b" } ];
+					data = [ { "a": "a" }, { "b": "b" } ];
 					break;
 				default:
 					throw new Error("No route for " + req.url);

--- a/test/leak_test.js
+++ b/test/leak_test.js
@@ -10,9 +10,10 @@ describe("Memory leaks", function(){
 
 	before(function(done){
 		helpers.createServer(8070, function(req, res){
+			var data;
 			switch(req.url) {
 				case "/bar":
-					var data = [ { "a": "a" }, { "b": "b" } ];
+					data = [ { "a": "a" }, { "b": "b" } ];
 					break;
 				default:
 					throw new Error("No route for " + req.url);

--- a/test/tests/async/orders/orders.js
+++ b/test/tests/async/orders/orders.js
@@ -14,7 +14,8 @@ var ViewModel = DefineMap.extend({
 					resolve(data);
 				};
 				xhr.onerror = function(err){
-					console.error(err);
+					var error = err || new Error(this.responseText);
+					console.error(error);
 				};
 				xhr.send();
 			});

--- a/test/xhr_test.js
+++ b/test/xhr_test.js
@@ -16,9 +16,10 @@ describe("xhr async rendering", function() {
 		});
 
 		helpers.createServer(8070, function(req, res){
+			var data;
 			switch(req.url) {
 				case "/api/list":
-					var data = [1,2,3,4,5];
+					data = [1,2,3,4,5];
 					break;
 				default:
 					throw new Error("No route for " + req.url);

--- a/zones/canjs/cleanup.js
+++ b/zones/canjs/cleanup.js
@@ -12,15 +12,15 @@ module.exports = function(data){
 			var domMutate = getDomMutate();
 
 			var docEl = data.document.documentElement;
-			var head = data.document.head;
-			var body = data.document.body;
+
+			// Run the removal within the zone so that the globals point to our globals.
+			var removeDocumentElement = this.wrap(function() {
+				domMutate.removeChild.call(data.document, docEl);
+			});
 
 			// Do this some time later to prevent extra mutations
 			// In the mutation stream
-			later(function(){
-				domMutate.removeChild.call(docEl, head);
-				domMutate.removeChild.call(docEl, body);
-			});
+			later(removeDocumentElement);
 		}
 	};
 };

--- a/zones/canjs/globals.js
+++ b/zones/canjs/globals.js
@@ -7,21 +7,24 @@ module.exports = function(data){
 	}
 
 	var getLocation = getEither.bind(null, "LOCATION", "can-globals/location/location");
-	var getDocument = getEither.bind(null, "DOCUMENT", "can-globals/document/document")
+	var getDocument = getEither.bind(null, "DOCUMENT", "can-globals/document/document");
 
 	var oldLocation, oldDocument;
 
+	function setCanGlobals() {
+		var LOCATION = getLocation();
+		var DOCUMENT = getDocument();
+
+		oldLocation = LOCATION();
+		LOCATION(data.window.location);
+
+		oldDocument = DOCUMENT();
+		DOCUMENT(data.window.document);
+	}
+
 	return {
-		beforeTask: function(){
-			var LOCATION = getLocation();
-			var DOCUMENT = getDocument();
-
-			oldLocation = LOCATION();
-			LOCATION(window.location);
-
-			oldDocument = DOCUMENT();
-			DOCUMENT(window.document);
-		},
+		afterStealDone: setCanGlobals,
+		beforeTask: setCanGlobals,
 		afterTask: function(){
 			getLocation()(oldLocation);
 			getDocument()(oldDocument);


### PR DESCRIPTION
This makes sure that we clean up the DOM inside of the zone that was
used to render the app. This ensure that callbacks made by
`can-dom-mutate` reference the correct document, and all of the
necessary memory is cleaned up.

This fixes #560