### PR TITLE
Prevent leak caused by saving promise with can-dom-data-state

### DIFF
--- a/lib/startup.js
+++ b/lib/startup.js
@@ -2,7 +2,8 @@ exports.modules = {
 	"can": "can-namespace",
 	"DOCUMENT": "can-globals/document/document",
 	"domMutate": "can-dom-mutate/node",
-	"LOCATION": "can-globals/location/location"
+	"LOCATION": "can-globals/location/location",
+	"globals": "can-globals"
 };
 
 // Logic that needs to run when steal starts up.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "uglify-js": "^3.3.19"
   },
   "dependencies": {
-    "can-dom-data-state": "^1.0.2",
     "can-dom-mutate": "^1.2.1",
     "can-namespace": "^1.0.0",
     "can-reflect": "^1.11.0",

--- a/test/leak_test.js
+++ b/test/leak_test.js
@@ -48,10 +48,12 @@ describe("Memory leaks", function(){
 		this.server.close();
 	});
 
-	it("No leaks occur after 10 iterations", function(done){
+	it("No leaks occur after iterations", function(done){
+		var options = { iterations: 1 };
+
 		var debug = typeof process.env.DONE_SSR_DEBUG !== "undefined";
 		var cnt = 0;
-		iterate(10, () => {
+		iterate.async(() => {
 			cnt++;
 			var thisIteration = cnt;
 			if(debug) {
@@ -63,7 +65,7 @@ describe("Memory leaks", function(){
 					console.error("After render", thisIteration);
 				}
 			});
-		})
+		}, options)
 		.then(() => {
 			done();
 		})

--- a/test/test.js
+++ b/test/test.js
@@ -23,7 +23,7 @@ mochas([
 	"define_map_status_test.js",
 	"define_test.js",
 	"live-reload_test.js",
-	//"leak_test.js",
+	"leak_test.js",
 	"incremental_test.js",
 	"incremental_plain_test.js",
 	"incremental_prog_test.js",

--- a/zones/canjs/globals.js
+++ b/zones/canjs/globals.js
@@ -6,28 +6,37 @@ module.exports = function(data){
 		return (data.modules && data.modules[propName]) || require(moduleName);
 	}
 
-	var getLocation = getEither.bind(null, "LOCATION", "can-globals/location/location");
-	var getDocument = getEither.bind(null, "DOCUMENT", "can-globals/document/document");
+	var getGlobals = getEither.bind(null, "globals", "can-globals");
 
 	var oldLocation, oldDocument;
 
 	function setCanGlobals() {
-		var LOCATION = getLocation();
-		var DOCUMENT = getDocument();
+		var globals = getGlobals();
+		
+		oldLocation = globals.getKeyValue("location");
+		globals.setKeyValue("location", data.window.location);
 
-		oldLocation = LOCATION();
-		LOCATION(data.window.location);
-
-		oldDocument = DOCUMENT();
-		DOCUMENT(data.window.document);
+		oldDocument = globals.getKeyValue("document");
+		globals.setKeyValue("document", data.window.document);
 	}
 
 	return {
 		afterStealDone: setCanGlobals,
 		beforeTask: setCanGlobals,
 		afterTask: function(){
-			getLocation()(oldLocation);
-			getDocument()(oldDocument);
+			var globals = getGlobals();
+
+			globals.setKeyValue("location", oldLocation);
+			globals.setKeyValue("document", oldDocument);
+		},
+		end: function() {
+			function teardown(globals) {
+				globals.deleteKeyValue("document");
+				globals.deleteKeyValue("location");
+			}
+
+			teardown(getGlobals());
+			teardown(require("can-globals"));
 		}
 	};
 };

--- a/zones/steal/styles/can-import.js
+++ b/zones/steal/styles/can-import.js
@@ -1,4 +1,4 @@
-var canData = require("can-dom-data-state");
+var pageNormalizeSymbol = Symbol.for("done.pageNormalizePromise");
 
 module.exports = function(data){
 	var oldCanImport, can;
@@ -21,7 +21,7 @@ module.exports = function(data){
 			}
 			pages.push(name);
 		});
-		canData.set.call(el, "pageNormalizePromise", pagePromise);
+		el[pageNormalizeSymbol] = pagePromise;
 
 		oldCanImport.apply(this, arguments);
 	};

--- a/zones/steal/styles/loaded.js
+++ b/zones/steal/styles/loaded.js
@@ -1,4 +1,4 @@
-var canData = require("can-dom-data-state");
+var pageNormalizeSymbol = Symbol.for("done.pageNormalizePromise");
 
 module.exports = function(){
 	return function(data){
@@ -13,7 +13,7 @@ module.exports = function(){
 		var oldCanImport;
 		var canImport = function(el){
 			var res = oldCanImport.apply(this, arguments);
-			var promise = canData.get.call(el, "pageNormalizePromise");
+			var promise = el[pageNormalizeSymbol];
 			promises.push(promise);
 			return res;
 		};


### PR DESCRIPTION
This prevents a leak caused by storing a promise with
can-dom-data-state. Since this instance of can-dom-data-state comes from
Node's module system and not Steal's, this doesn't get cleaned up when
we clean up memory with can-dom-mutate.

In this case we can replace the usage with Symbols.

This commit also turns back on the memory leak test, which is now
passing. Closes #560