### PR TITLE
Allow incremental rendering to occur over HTTP/1

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,3 @@
 lib/strategies/incremental/client/dist/
 lib/strategies/incremental/client/node_modules/
+test/incremental_h1_test.js

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var defaults = require("lodash.defaults");
+var getPath = require("./util/get_path");
 var SSRStream = require("./ssr-stream");
 
 // I don't know if we need this...
@@ -8,10 +9,16 @@ module.exports = function(config, options){
 	var opts = defaults(options, {
 		timeout: 5000,
 		useCacheNormalize: true,
-		steal: config
+		steal: config,
+		streamMap: new Map()
 	});
 
 	return function(requestOrUrl){
+		var path = getPath(requestOrUrl);
+		if(opts.streamMap.has(path)) {
+			return opts.streamMap.get(path);
+		}
+
 		return new SSRStream(requestOrUrl, opts);
 	};
 };

--- a/lib/ssr-stream.js
+++ b/lib/ssr-stream.js
@@ -54,7 +54,7 @@ SafeStream.prototype.render = function(){
 	var incremental = this.options.strategy === "incremental";
 
 	if(incremental) {
-		zones.push(pushMutations(response));
+		zones.push(pushMutations(request, response, undefined, this.options.streamMap));
 		zones.push(pushFetch(response));
 		zones.push(pushXHR(response));
 	}

--- a/lib/util/get_path.js
+++ b/lib/util/get_path.js
@@ -1,0 +1,11 @@
+var URL = require("url").URL;
+
+module.exports = function(headersOrRequestOrUrl) {
+	if(typeof headersOrRequestOrUrl === "string") {
+		return new URL(headersOrRequestOrUrl).pathname;
+	} else if(headersOrRequestOrUrl[":path"]) {
+		return headersOrRequestOrUrl[":path"];
+	} else {
+		return headersOrRequestOrUrl.url;
+	}
+};

--- a/lib/util/get_path.js
+++ b/lib/util/get_path.js
@@ -2,7 +2,7 @@ var URL = require("url").URL;
 
 module.exports = function(headersOrRequestOrUrl) {
 	if(typeof headersOrRequestOrUrl === "string") {
-		return new URL(headersOrRequestOrUrl).pathname;
+		return new URL(headersOrRequestOrUrl, "http://localhost:8080").pathname;
 	} else if(headersOrRequestOrUrl[":path"]) {
 		return headersOrRequestOrUrl[":path"];
 	} else {

--- a/lib/util/is_http1_request.js
+++ b/lib/util/is_http1_request.js
@@ -1,0 +1,7 @@
+
+// An IncomingMessage always has a `.headers` property.
+function isIncomingMessage(request) {
+	return !!request.headers;
+}
+
+module.exports = isIncomingMessage;

--- a/lib/util/make_headers.js
+++ b/lib/util/make_headers.js
@@ -1,9 +1,10 @@
+var isHTTP1Request = require("./is_http1_request");
 
 // This converts a HTTP/1 Request to HTTP/2 headers object
 module.exports = function(request) {
 	// Assume anything that doesn't look like an IncomingMessage is already
 	// an HTTP/2 headers object
-	if(!isIncomingMessage(request)) {
+	if(!isHTTP1Request(request)) {
 		return request;
 	}
 
@@ -24,8 +25,3 @@ module.exports = function(request) {
 
 	return headers;
 };
-
-// An IncomingMessage always has a `.headers` property.
-function isIncomingMessage(request) {
-	return !!request.headers;
-}

--- a/lib/util/safe_push.js
+++ b/lib/util/safe_push.js
@@ -1,6 +1,10 @@
 var Readable = require("stream").Readable;
 
 module.exports = function(url, options, data, stream){
+	if(stream.stream) {
+		stream = stream.stream;
+	}
+
 	if(stream.pushStream) {
 		stream.pushStream({":path": url}, (err, pushStream) => {
 			if(err) {
@@ -9,7 +13,6 @@ module.exports = function(url, options, data, stream){
 
 			pushStream.respond({
 				":status": 200,
-				":method": "GET",
 				"content-type": "application/json"
 			});
 

--- a/lib/util/set_http_version.js
+++ b/lib/util/set_http_version.js
@@ -1,0 +1,8 @@
+var isHTTP1Request = require("./is_http1_request");
+
+module.exports = function(data, request) {
+	var isH1 = isHTTP1Request(request);
+	data.httpVersion = isH1 ? "h1" : "h2";
+	data.isHTTP1 = isH1;
+	data.isHTTP2 = !isH1;
+};

--- a/test/helpers/dom.js
+++ b/test/helpers/dom.js
@@ -1,8 +1,6 @@
 var makeWindow = require("can-vdom/make-window/make-window");
 var document = makeWindow({}).document;
-var http = require("http");
 var he = require("he");
-var moUtils = require("done-mutation-observer");
 
 exports.dom = function(html){
 	html = html.replace("<!doctype html>", "").trim();
@@ -99,87 +97,4 @@ exports.count = function(node, callback){
 		}
 	});
 	return count;
-};
-
-// A good enough XHR object
-exports.mockXHR = function(responseFN, options){
-	options = options || {};
-	if(typeof responseFN === "string") {
-		var responseText = responseFN;
-		responseFN = function(){
-			return responseText;
-		};
-	}
-	var XHR = function(){
-		this.onload = null;
-		this.__events = {};
-		this.__headers = {};
-	};
-	var realSetTimeout = global.setTimeout;
-	XHR.prototype.addEventListener = function(ev, fn){
-		var evs = this.__events[ev] = this.__events[ev] || [];
-		evs.push(fn);
-	};
-	XHR.prototype.setRequestHeader = function(name, value){
-		this.__headers[name] = value;
-	};
-	XHR.prototype.getRequestHeader = function(name){
-		return this.__headers[name];
-	};
-	XHR.prototype.getResponseHeader = function(){};
-	XHR.prototype.open = function(){};
-	XHR.prototype.send = function(){
-		var onload = this.onload;
-		var onerror = this.onerror;
-		var xhr = this;
-		realSetTimeout(function(){
-			if(options.error) {
-				callEvents(xhr, "error");
-				if(onerror) {
-					onerror({ target: xhr });
-				}
-				return;
-			}
-
-			xhr.responseText = responseFN();
-			onload({ target: xhr });
-			callEvents(xhr, "load");
-		}, 40);
-		if (options.beforeSend) {
-			options.beforeSend(this);
-		}
-	};
-	function callEvents(xhr, ev) {
-		var evs = xhr.__events[ev] || [];
-		evs.forEach(function(fn){
-			fn.call(xhr);
-		});
-	}
-	XHR.prototype.setDisableHeaderCheck = function(){};
-	XHR.prototype.getAllResponseHeaders = function(){
-		return "Content-Type: application/json";
-	};
-	return XHR;
-};
-
-exports.ua = {
-	chrome: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.109 Safari/537.36"
-};
-
-exports.createServer = function(port, cb){
-	var server = http.createServer(cb).listen(port);
-
-	return new Promise((resolve, reject) => {
-		server.on("listening", function(){
-			resolve(server);
-		});
-	});
-};
-
-exports.removeMutationObserverZone = function(data) {
-	return {
-		ended: function(){
-			moUtils.removeMutationObserver(data.window);
-		}
-	};
 };

--- a/test/helpers/incremental.js
+++ b/test/helpers/incremental.js
@@ -1,0 +1,28 @@
+var domHelpers = require("./dom");
+var he = require("he");
+var MutationDecoder = require("done-mutation/decoder");
+
+exports.findMutationDoc = function(node) {
+	var node = domHelpers.find(node, n => {
+		return n && n.getAttribute && n.getAttribute("id") === "donessr-iframe";
+	});
+	var srcdoc = node.getAttribute("srcdoc");
+	var str = he.decode(he.decode(srcdoc));
+	return domHelpers.dom(str);
+}
+
+exports.extractInstructionsURL = function(html) {
+	var node = domHelpers.dom(html);
+	var mutationDoc = exports.findMutationDoc(node);
+	var preload = domHelpers.find(mutationDoc, n => {
+		return n && n.getAttribute && n.getAttribute("rel") === "preload";
+	});
+	return preload && preload.getAttribute("href");
+};
+
+exports.decodeMutations = function(bytes) {
+	var doc = domHelpers.dom("<html></html>").ownerDocument;
+	var decoder = new MutationDecoder(doc);
+	var mutations = Array.from(decoder.decode(bytes));
+	return mutations;
+};

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,0 +1,20 @@
+var moUtils = require("done-mutation-observer");
+
+exports.mockXHR = require("./xhr");
+
+Object.assign(exports, require("./dom"));
+Object.assign(exports, require("./incremental"));
+Object.assign(exports, require("./request"));
+Object.assign(exports, require("./server"));
+
+exports.ua = {
+	chrome: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.109 Safari/537.36"
+};
+
+exports.removeMutationObserverZone = function(data) {
+	return {
+		ended: function(){
+			moUtils.removeMutationObserver(data.window);
+		}
+	};
+};

--- a/test/helpers/request.js
+++ b/test/helpers/request.js
@@ -1,0 +1,60 @@
+var http = require("http");
+var URL = require("url").URL;
+
+exports.makeRequest = async function(url, encoding = "utf8") {
+	let urlObj = new URL(url);
+	return makeH1Request(urlObj, encoding);
+};
+
+function makeH1Request(urlObj, encoding) {
+	let response = {body: []};
+	return new Promise((resolve, reject) => {
+		let options = {
+			hostname: urlObj.hostname,
+			port: Number(urlObj.port),
+			path: urlObj.pathname + urlObj.search,
+			method: 'GET'
+		};
+
+		if(urlObj.protocol === "https:") {
+			options.rejectUnauthorized = false;
+		}
+
+		http.get(options, res => {
+			response.statusCode = res.statusCode;
+			response.headers = res.headers;
+
+			if(response.statusCode === 301) {
+				let urlObj = new URL(response.headers.location);
+				resolve(makeH1Request(urlObj, encoding));
+				return;
+			}
+
+			if(encoding) {
+				res.setEncoding(encoding); // Usually utf8
+			}
+
+			res.on("data", chunk => {
+				if(!encoding) {
+					for (let byte of chunk) {
+						response.body.push(byte);
+					}
+				}
+
+				response.body.push(chunk);
+			});
+			res.on("end", () => {
+				if(encoding) {
+					response.body = response.body.join("");
+				} else {
+					response.body = Uint8Array.from(response.body);
+				}
+
+				resolve(response);
+			});
+		})
+		.on("error", error => {
+			reject(error);
+		});
+	});
+}

--- a/test/helpers/server.js
+++ b/test/helpers/server.js
@@ -1,0 +1,28 @@
+var http = require("http");
+
+exports.createServer = function(port, cb){
+	var server = http.createServer(cb).listen(port);
+
+	return new Promise((resolve, reject) => {
+		server.on("listening", function(){
+			resolve(server);
+		});
+	});
+};
+
+exports.serveAPI = function(port = 8070) {
+	var handler  = function(req, res){
+		var data;
+		switch(req.url) {
+			case "/bar":
+				data = [ { "a": "a" }, { "b": "b" } ];
+				res.setHeader("Content-Type", "application/json");
+				res.end(JSON.stringify(data));
+				break;
+			default:
+				throw new Error("No route for " + req.url);
+		}
+	};
+
+	return exports.createServer(port, handler);
+};

--- a/test/helpers/xhr.js
+++ b/test/helpers/xhr.js
@@ -1,0 +1,61 @@
+
+// A good enough XHR object
+module.exports = function(responseFN, options){
+	options = options || {};
+	if(typeof responseFN === "string") {
+		var responseText = responseFN;
+		responseFN = function(){
+			return responseText;
+		};
+	}
+	var XHR = function(){
+		this.onload = null;
+		this.__events = {};
+		this.__headers = {};
+	};
+	var realSetTimeout = global.setTimeout;
+	XHR.prototype.addEventListener = function(ev, fn){
+		var evs = this.__events[ev] = this.__events[ev] || [];
+		evs.push(fn);
+	};
+	XHR.prototype.setRequestHeader = function(name, value){
+		this.__headers[name] = value;
+	};
+	XHR.prototype.getRequestHeader = function(name){
+		return this.__headers[name];
+	};
+	XHR.prototype.getResponseHeader = function(){};
+	XHR.prototype.open = function(){};
+	XHR.prototype.send = function(){
+		var onload = this.onload;
+		var onerror = this.onerror;
+		var xhr = this;
+		realSetTimeout(function(){
+			if(options.error) {
+				callEvents(xhr, "error");
+				if(onerror) {
+					onerror({ target: xhr });
+				}
+				return;
+			}
+
+			xhr.responseText = responseFN();
+			onload({ target: xhr });
+			callEvents(xhr, "load");
+		}, 40);
+		if (options.beforeSend) {
+			options.beforeSend(this);
+		}
+	};
+	function callEvents(xhr, ev) {
+		var evs = xhr.__events[ev] || [];
+		evs.forEach(function(fn){
+			fn.call(xhr);
+		});
+	}
+	XHR.prototype.setDisableHeaderCheck = function(){};
+	XHR.prototype.getAllResponseHeaders = function(){
+		return "Content-Type: application/json";
+	};
+	return XHR;
+};

--- a/test/incremental_h1_test.js
+++ b/test/incremental_h1_test.js
@@ -1,0 +1,49 @@
+var ssr = require("../lib/");
+var helpers = require("./helpers");
+var incHelpers = require("./inc_helpers");
+var http = require("http");
+var assert = require("assert");
+var path = require("path");
+var MutationDecoder = require("done-mutation/decoder");
+var URL = require("url").URL;
+
+describe("Incremental rendering with HTTP/1", function(){
+	this.timeout(10000);
+
+	before(async function(){
+		this.apiServer = await helpers.serveAPI();
+		this.server = await helpers.createServer(8071, (req, res) => {
+			this.render(req).pipe(res);
+		});
+
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "async/index.stache!done-autorender"
+		}, {
+			strategy: "incremental"
+		});
+	});
+
+	after(function(){
+		this.apiServer.close();
+		this.server.close();
+	});
+
+	describe("A basic async app", function(){
+		before(async function(){
+			this.htmlResponse = await helpers.makeRequest("http://localhost:8071/");
+			var instrURL = helpers.extractInstructionsURL(this.htmlResponse.body);
+			var endpoint = new URL(instrURL, "http://localhost:8071");
+			this.mutationResponse = await helpers.makeRequest(endpoint.toString(), false);
+
+			this.mutations = helpers.decodeMutations(this.mutationResponse.body);
+		});
+
+		it("Sends mutation instruction for order-history", function(){
+			var oh = this.mutations[3];
+
+			assert.equal(oh.type, "insert");
+			assert.equal(oh.node.nodeName, "ORDER-HISTORY");
+		});
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,7 @@ mochas([
 	"live-reload_test.js",
 	"leak_test.js",
 	"incremental_test.js",
+	"incremental_h1_test.js",
 	"incremental_plain_test.js",
 	"incremental_prog_test.js",
 	"error_handling_test.js"

--- a/zones/push-mutations/index.js
+++ b/zones/push-mutations/index.js
@@ -1,8 +1,17 @@
+var makeHeaders = require("../../lib/util/make_headers");
 var mutations = require("../mutations");
 var reattach = require("./reattach");
+var setHTTPVersion = require("../../lib/util/set_http_version");
 
-module.exports = function(stream, url = `/_donessr_instructions/${Date.now()}`){
+module.exports = function(requestOrHeaders, stream,
+	url = `/_donessr_instructions/${Date.now()}`, pushStreams = new Map()) {
+	var headers = makeHeaders(requestOrHeaders);
+	if(stream.stream) {
+		stream = stream.stream;
+	}
+
 	return function(data){
+		setHTTPVersion(data, requestOrHeaders);
 		var instrStream;
 
 		return {
@@ -12,12 +21,18 @@ module.exports = function(stream, url = `/_donessr_instructions/${Date.now()}`){
 			],
 
 			created: function(){
+				// If this is HTTP/1 a preload link is added.
+				if(data.isHTTP1) {
+					pushStreams.set(url, data.mutations);
+					return;
+				}
+
+				// Must be http/2 then
 				stream.pushStream({":path": url}, (err, pushStream) => {
 					if(err) throw err;
 
 					pushStream.respond({
 						":status": 200,
-						":method": "GET",
 						"content-type": "text/plain"
 					});
 

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -134,7 +134,7 @@ describe("SSR Zones - Incremental Rendering with DoneJS", function(){
 		var idom = helpers.dom(html);
 
 		var reattach = helpers.find(idom, node => node.nodeType === 1 &&
-			node.hasAttribute("data-streamurl"));
+			node.getAttribute("type") === "module");
 		var parent = reattach.parentNode;
 
 		assert.equal(parent.nodeName, "HEAD", "within the head");

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -53,7 +53,7 @@ describe("SSR Zones - Incremental Rendering", function(){
 					// Sets up a DOM
 					dom(headers),
 
-					pushMutations(stream),
+					pushMutations(headers, stream),
 
 					helpers.removeMutationObserverZone
 				]);
@@ -114,7 +114,7 @@ describe("SSR Zones - Incremental Rendering with DoneJS", function(){
 					main: "async/index.stache!done-autorender"
 				}, stream),
 
-				pushMutations(stream),
+				pushMutations(headers, stream),
 				helpers.removeMutationObserverZone
 			]);
 


### PR DESCRIPTION
This adds support for incremental rendering through HTTP/1. This works
by attaching a `<link rel=preload>` to the document which will preload
the rendering instructions, which happens in place of the H2 PUSH.
Closes #582