### PR TITLE
Serialize iframe document

### DIFF
--- a/zones/mutations.js
+++ b/zones/mutations.js
@@ -1,5 +1,4 @@
 var assert = require("assert");
-var cloneUtils = require("ir-clone");
 var isPromise = require("is-promise");
 var Readable = require("stream").Readable;
 var moUtils = require("done-mutation-observer");
@@ -21,12 +20,7 @@ module.exports = function(){
 		}
 
 		function startListeningToMutations() {
-			Object.defineProperty(data, "html", {
-				value: cloneUtils.serializeToString(data.document),
-				enumerable: true,
-				configurable: true,
-				writable: false
-			});
+			data.html = data.document.documentElement.outerHTML;
 
 			observer.observe(data.document, {
 				subtree: true,
@@ -55,11 +49,11 @@ module.exports = function(){
 					data.startMutations.then(startListeningToMutations);
 				} else {
 					startListeningToMutations();
-					data.html = cloneUtils.serializeToString(data.document);
+					data.html = data.document.documentElement.outerHTML;
 				}
 			},
 			afterStealMain: function(){
-				data.html = cloneUtils.serializeToString(data.document);
+				data.html = data.document.documentElement.outerHTML;
 			},
 			ended: function(){
 				observer.disconnect();

--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -1,6 +1,7 @@
 var fs = require("fs");
 var isPromise = require("is-promise");
 var path = require("path");
+var cloneUtils = require("ir-clone");
 
 var clientScript = getClientScript();
 
@@ -65,7 +66,7 @@ module.exports = function(url){
 		var iframe = document.createElement("iframe");
 		iframe.setAttribute("id", "donessr-iframe");
 		iframe.setAttribute("data-keep", "");
-		iframe.setAttribute("srcdoc", clone.outerHTML);
+		iframe.setAttribute("srcdoc", cloneUtils.serializeToString(clone));
 		iframe.setAttribute("style", "border:0;position:fixed;top:0;left:0;right:0;bottom:0;width:100%;height:100%;visibility:visible;");
 		return iframe;
 	}

--- a/zones/tests/basics/main.js
+++ b/zones/tests/basics/main.js
@@ -3,6 +3,8 @@ module.exports = function(){
 	var main = document.createElement("main");
 	var ul = document.createElement("ul");
 	main.appendChild(ul);
+	main.appendChild(document.createTextNode("\n"));
+	main.appendChild(document.createTextNode("Testing"));
 
 	var statusSpan = document.createElement("span");
 	statusSpan.className = "status";

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -81,6 +81,22 @@ describe("SSR Zones - Incremental Rendering", function(){
 			assert.ok(!ul.firstChild, "There are no child LIs yet");
 		});
 
+		it("iframe doc contains TextNode separators", function() {
+			var dom = helpers.dom(this.zone.data.initialHTML);
+			var iframe = helpers.find(dom, node => node.nodeName === "IFRAME");
+			var html = helpers.decodeSrcDoc(iframe);
+			var idom = helpers.dom(html);
+
+			var comments = 0;
+			helpers.traverse(idom, node => {
+				if(node.nodeType === 8 && node.nodeValue === "__DONEJS-SEP__") {
+					comments++;
+				}
+			});
+
+			assert.ok(comments > 0, "There are some separator comment nodes");
+		});
+
 		it("Contains mutations", function(){
 			var decoder = new MutationDecoder(this.zone.data.document);
 			var pushes = this.stream.data.pushes;


### PR DESCRIPTION
We should be serializing the iframe document using ir-clone in order to
ensure that its comment nodes are injected.