### PR TITLE
Run nodeIndex before starting to listen to mutations.

### DIFF
--- a/zones/mutations.js
+++ b/zones/mutations.js
@@ -20,7 +20,6 @@ module.exports = function(){
 		}
 
 		function startListeningToMutations() {
-			nodeIndex.stopObserving();
 			if(typeof data.injectIRFrame === "function") {
 				data.injectIRFrame();
 				nodeIndex.reindex();
@@ -44,7 +43,6 @@ module.exports = function(){
 				observer = new MutationObserver(onMutations);
 				nodeIndex = new NodeIndex(data.document);
 				encoder = new MutationEncoder(nodeIndex);
-				nodeIndex.startObserving();
 				data.mutations = mutationStream;
 			},
 			afterRun: function(){
@@ -62,7 +60,6 @@ module.exports = function(){
 			},
 			ended: function(){
 				observer.disconnect();
-				nodeIndex.stopObserving();
 				mutationStream.push(null);
 			}
 		};


### PR DESCRIPTION
This removes the prior indexing which can get out of sync. This will
likely be deprecated from done-mutation as its no longer needed in
done-ssr