### PR TITLE
Leave on a documentElement on the document.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "done-autorender": "^2.2.0",
     "done-css": "^3.0.1",
     "es6-promise": "^4.1.0",
+    "fast-text-encoding": "^1.0.0",
     "he": "^1.1.1",
     "jquery": "2.x - 3.x",
     "jshint": "^2.8.0",

--- a/test/helpers/incremental.js
+++ b/test/helpers/incremental.js
@@ -1,5 +1,6 @@
 var domHelpers = require("./dom");
 var he = require("he");
+require('fast-text-encoding');
 var MutationDecoder = require("done-mutation/decoder");
 
 exports.findMutationDoc = function(node) {

--- a/zones/canjs/cleanup.js
+++ b/zones/canjs/cleanup.js
@@ -15,7 +15,8 @@ module.exports = function(data){
 
 			// Run the removal within the zone so that the globals point to our globals.
 			var removeDocumentElement = this.wrap(function() {
-				domMutate.removeChild.call(data.document, docEl);
+				var newDocEl = data.document.createElement("html");
+				domMutate.replaceChild.call(data.document, newDocEl, docEl);
 			});
 
 			// Do this some time later to prevent extra mutations

--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -7,6 +7,7 @@ var clientScript = getClientScript();
 
 module.exports = function(url){
 	function appendToHead(document, element){
+		if(!document.head) return;
 		var fc = document.head.firstChild;
 		if(fc) {
 			document.head.insertBefore(element, fc);

--- a/zones/zones-mutations-test.js
+++ b/zones/zones-mutations-test.js
@@ -7,6 +7,7 @@ var pushMutations = require("./push-mutations");
 var pushXHR = require("./push-xhr");
 var donejs = require("./donejs");
 var he = require("he");
+require('fast-text-encoding');
 var MutationDecoder = require("done-mutation/decoder");
 
 var assert = require("assert");


### PR DESCRIPTION
We remove the `documentElement` in order to allow all of memory cleanup
to occur. However some libraries, like jQuery freak out when a document
doesn't have a documentElement.

The solution is to instead replace the documentElement with a new one.
This means there still is one, but the old one can have its memory
cleaned up.