### PR TITLE
Sets the preload link "as"

### DIFF
--- a/lib/util/set_http_version.js
+++ b/lib/util/set_http_version.js
@@ -1,8 +1,9 @@
 var isHTTP1Request = require("./is_http1_request");
 
-module.exports = function(data, request) {
+module.exports = function(data, request, stream) {
 	var isH1 = isHTTP1Request(request);
 	data.httpVersion = isH1 ? "h1" : "h2";
 	data.isHTTP1 = isH1;
 	data.isHTTP2 = !isH1;
+	data.pushAllowed = !!(data.isHTTP2 && stream.pushAllowed);
 };

--- a/test/helpers/incremental.js
+++ b/test/helpers/incremental.js
@@ -10,7 +10,12 @@ exports.findMutationDoc = function(node) {
 	var srcdoc = node.getAttribute("srcdoc");
 	var str = he.decode(he.decode(srcdoc));
 	return domHelpers.dom(str);
-}
+};
+
+exports.extractIframeDoc = function(html) {
+	var node = domHelpers.dom(html);
+	return exports.findMutationDoc(node);
+};
 
 exports.extractInstructionsURL = function(html) {
 	var node = domHelpers.dom(html);

--- a/test/inc_helpers.js
+++ b/test/inc_helpers.js
@@ -18,6 +18,7 @@ exports.mock = function(url, expectedPushes){
 	var H2Stream = class extends Duplex {
 		constructor(options) {
 			super(options);
+			this.pushAllowed = true;
 		}
 		// We only need this if we have a POST body
 		_read() {}

--- a/test/incremental_h1_test.js
+++ b/test/incremental_h1_test.js
@@ -45,5 +45,15 @@ describe("Incremental rendering with HTTP/1", function(){
 			assert.equal(oh.type, "insert");
 			assert.equal(oh.node.nodeName, "ORDER-HISTORY");
 		});
+
+		it("Includes the preload link in the iframe document", function(){
+			var doc = helpers.extractIframeDoc(this.htmlResponse.body);
+			var link = helpers.find(doc, function(node) {
+				return node.getAttribute && node.getAttribute("rel") === "preload";
+			});
+
+			assert.ok(link, "Preload link exists");
+			assert.equal(link.getAttribute("as"), "fetch", "has the correct 'as'");
+		});
 	});
 });

--- a/test/incremental_h1_test.js
+++ b/test/incremental_h1_test.js
@@ -54,6 +54,7 @@ describe("Incremental rendering with HTTP/1", function(){
 
 			assert.ok(link, "Preload link exists");
 			assert.equal(link.getAttribute("as"), "fetch", "has the correct 'as'");
+			assert.equal(link.getAttribute("crossorigin"), "anonymous", "set as anonymous");
 		});
 	});
 });

--- a/zones/push-mutations/index.js
+++ b/zones/push-mutations/index.js
@@ -11,7 +11,7 @@ module.exports = function(requestOrHeaders, stream,
 	}
 
 	return function(data){
-		setHTTPVersion(data, requestOrHeaders);
+		setHTTPVersion(data, requestOrHeaders, stream);
 		var instrStream;
 
 		return {
@@ -22,7 +22,7 @@ module.exports = function(requestOrHeaders, stream,
 
 			created: function(){
 				// If this is HTTP/1 a preload link is added.
-				if(data.isHTTP1) {
+				if(!data.pushAllowed) {
 					pushStreams.set(url, data.mutations);
 					return;
 				}

--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -53,6 +53,7 @@ module.exports = function(url){
 			var link = data.document.createElement("link");
 			link.setAttribute("rel", "preload");
 			link.setAttribute("as", "fetch");
+			link.setAttribute("crossorigin", "anonymous");
 			link.setAttribute("href", url);
 			appendToHead(fakeDoc, link);
 		}

--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -52,6 +52,7 @@ module.exports = function(url){
 		if(data.isHTTP1) {
 			var link = data.document.createElement("link");
 			link.setAttribute("rel", "preload");
+			link.setAttribute("as", "fetch");
 			link.setAttribute("href", url);
 			appendToHead(fakeDoc, link);
 		}

--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -49,7 +49,7 @@ module.exports = function(url){
 		appendToHead(fakeDoc, document.createComment("iframe placeholder"));
 
 		// Preload
-		if(data.isHTTP1) {
+		if(!data.pushAllowed) {
 			var link = data.document.createElement("link");
 			link.setAttribute("rel", "preload");
 			link.setAttribute("as", "fetch");
@@ -91,7 +91,7 @@ module.exports = function(url){
 		function injectStuff() {
 			let doc = data.document;
 			injectIntoHead(doc, makeIframe(doc, data));
-			if(data.isHTTP1) {
+			if(!data.pushAllowed) {
 				// Preload link placeholder
 				injectIntoHead(doc, doc.createComment("autorender-keep preload placeholder"));
 			}


### PR DESCRIPTION
To "fetch". This is necessary to get the browser to start preloading the
rendering instructions. Closes #600