### PR TITLE
Allow an alternative dom zone to be provided.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 script: npm test
 node_js:
-  - 10.7
+  - 10.14.2
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var defaults = require("lodash.defaults");
 var getPath = require("./util/get_path");
 var SSRStream = require("./ssr-stream");
 var LRU = require("lru-cache");
+var simpleDOM = require("../zones/can-simple-dom");
 
 // I don't know if we need this...
 global.doneSsr = {};
@@ -12,7 +13,8 @@ module.exports = function(config, options){
 		useCacheNormalize: true,
 		steal: config,
 		strategy: "incremental",
-		streamMap: new LRU()
+		streamMap: new LRU(),
+		domZone: simpleDOM
 	});
 
 	return function(requestOrUrl){

--- a/lib/ssr-stream.js
+++ b/lib/ssr-stream.js
@@ -11,7 +11,6 @@ var pushFetch = require("../zones/push-fetch");
 var pushMutations = require("../zones/push-mutations");
 var pushXHR = require("../zones/push-xhr");
 var requests = require("../zones/requests");
-var simpleDOM = require("../zones/can-simple-dom");
 var supportsIncremental = require("./util/supports_incremental");
 
 var timeout = require("can-zone/timeout");
@@ -40,7 +39,7 @@ SafeStream.prototype.render = function(){
 
 	var zones = [
 		requests(request, this.options),
-		simpleDOM(request),
+		this.options.domZone(request, response),
 		donejs(this.options.steal, response),
 		cookies(request, response)
 	];

--- a/test/zones_test.js
+++ b/test/zones_test.js
@@ -1,0 +1,111 @@
+var ssr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+var through = require("through2");
+var simpleDOM = require("../zones/can-simple-dom");
+
+describe("Providing additional zones", function(){
+	this.timeout(10000);
+
+	before(function(done){
+		this.render = ssr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "async/index.stache!done-autorender"
+		}, {
+			strategy: "seo",
+			zones: [
+				function(data) {
+					return {
+						afterStealMain: function() {
+							data.addMe();
+							var doc = data.document;
+							var span = doc.createElement("span");
+							span.setAttribute("id", "from-zone");
+							doc.body.appendChild(span);
+						}
+					};
+				}
+			],
+			domZone: function(request) {
+				return function(data) {
+					data.addMe = function() {
+						var doc = data.document;
+						var span = doc.createElement("span");
+						span.setAttribute("id", "dom-zone");
+						doc.body.appendChild(span);
+					};
+
+					return {
+						plugins: [
+							simpleDOM(request)
+						]
+					};
+				};
+			}
+		});
+
+		helpers.createServer(8070, function(req, res){
+			var data;
+			switch(req.url) {
+				case "/bar":
+					data = [ { "a": "a" }, { "b": "b" } ];
+					res.setHeader("Content-Type", "application/json");
+					res.end(JSON.stringify(data));
+					break;
+				default:
+					throw new Error("No route for " + req.url);
+			}
+		})
+		.then(server => {
+			this.server = server;
+			done();
+		});
+	});
+
+	after(function(){
+		this.server.close();
+	});
+
+	it("Uses the additional zones", function(done) {
+		var renderStream = this.render("/");
+
+		renderStream.on("error", done);
+
+		renderStream.pipe(through(function(buffer){
+			Promise.resolve().then(function(){
+				var html = buffer.toString();
+				var node = helpers.dom(html);
+
+				var span = helpers.find(node, function(n){
+					return n.getAttribute && n.getAttribute("id") === "from-zone";
+				});
+
+				assert.ok(span, "Rendered a span that was added by another zone");
+				done();
+			})
+			.catch(done);
+		}));
+	});
+
+	it("Uses the domZone for applying the DOM zone.", function(done) {
+		var renderStream = this.render("/");
+
+		renderStream.on("error", done);
+
+		renderStream.pipe(through(function(buffer){
+			Promise.resolve().then(function(){
+				var html = buffer.toString();
+				var node = helpers.dom(html);
+
+				var span = helpers.find(node, function(n){
+					return n.getAttribute && n.getAttribute("id") === "dom-zone";
+				});
+
+				assert.ok(span, "Rendered a span that was added by the dom zone");
+				done();
+			})
+			.catch(done);
+		}));
+	});
+});


### PR DESCRIPTION
This allows an alternative dom zone to be provided to done-ssr through
the `domZone` option. By default done-ssr uses can-simple-dom. There is
also the can-zone-jsdom that some might prefer to use and this provides
that option.

The signature is:

```js
{
  domZone: function(request, response) {

  }
}
```