### PR TITLE
Allow providing a function into ssr()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,13 +8,16 @@ var simpleDOM = require("../zones/can-simple-dom");
 global.doneSsr = {};
 
 module.exports = function(config, options){
+	var runFn = typeof config === "function" && config;
+
 	var opts = defaults(options, {
 		timeout: 5000,
 		useCacheNormalize: true,
-		steal: config,
+		steal: runFn ? false: config,
 		strategy: "incremental",
 		streamMap: new LRU(),
-		domZone: simpleDOM
+		domZone: simpleDOM,
+		fn: runFn
 	});
 
 	return function(requestOrUrl){

--- a/lib/ssr-stream.js
+++ b/lib/ssr-stream.js
@@ -3,10 +3,8 @@ var Readable = require("stream").Readable;
 var util = require("util");
 
 var Zone = require("can-zone");
-
 var cookies = require("../zones/cookies");
 var debug = require("../zones/debug");
-var donejs = require("../zones/donejs");
 var pushFetch = require("../zones/push-fetch");
 var pushMutations = require("../zones/push-mutations");
 var pushXHR = require("../zones/push-xhr");
@@ -39,10 +37,15 @@ SafeStream.prototype.render = function(){
 
 	var zones = [
 		requests(request, this.options),
-		this.options.domZone(request, response),
-		donejs(this.options.steal, response),
-		cookies(request, response)
+		this.options.domZone(request, response)
 	];
+
+	if(this.options.steal !== false) {
+		var donejs = require("../zones/donejs");
+		zones.push(donejs(this.options.steal, response));
+	}
+
+	zones.push(cookies(request, response));
 
 	var timeoutZone = timeout(this.options.timeout);
 	zones.push(timeoutZone);
@@ -67,13 +70,16 @@ SafeStream.prototype.render = function(){
 	// Make sure the `ready` process is caught, to prevent unhandledRejection
 	zones.push({
 		created: function(){
-			this.data.ready.catch(err => {});
+			if(this.data.ready) {
+				this.data.ready.catch(err => {});
+			}
 		}
 	});
 
 	var zone = new Zone(zones);
 
-	var runPromise = zone.run();
+	var runFn = this.options.fn || void 0;
+	var runPromise = zone.run(runFn);
 
 	if(incremental) {
 		var donePromise = runPromise;

--- a/test/fn_test.js
+++ b/test/fn_test.js
@@ -1,0 +1,34 @@
+var ssr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var through = require("through2");
+
+describe("fn main", function(){
+	this.timeout(10000);
+
+	before(function(){
+		function render() {
+			var el = document.createElement("main");
+			document.body.appendChild(el);
+		}
+
+		this.render = ssr(render);
+	});
+
+	it("basics works", function(done){
+		var renderStream = this.render("/");
+
+		renderStream.on("error", done);
+
+		renderStream.pipe(through(function(buffer){
+			Promise.resolve().then(function(){
+				var html = buffer.toString();
+				var node = helpers.dom(html);
+				var main = node.getElementsByTagName("main")[0];
+
+				assert.ok(main, "The app was rendered from the provided fn");
+			})
+			.then(done, done);
+		}));
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -28,5 +28,6 @@ mochas([
 	"incremental_h1_test.js",
 	"incremental_plain_test.js",
 	"incremental_prog_test.js",
-	"error_handling_test.js"
+	"error_handling_test.js",
+	"fn_test.js"
 ], __dirname);


### PR DESCRIPTION
This changes it so that a function can be provided as the first
argument, instead of a steal configuration. Doing this you do not use
steal, but rather the function executes.

```js
const ssr = require("done-ssr");

const render = ssr(() => {
	let el = document.createElement("div");
	document.body.appendChild(el);
});

require("http").createServer(render);
```