### PR TITLE
Leave on a documentElement on the document.

### DIFF
--- a/zones/canjs/cleanup.js
+++ b/zones/canjs/cleanup.js
@@ -15,7 +15,8 @@ module.exports = function(data){
 
 			// Run the removal within the zone so that the globals point to our globals.
 			var removeDocumentElement = this.wrap(function() {
-				domMutate.removeChild.call(data.document, docEl);
+				var newDocEl = data.document.createElement("html");
+				domMutate.replaceChild.call(data.document, newDocEl, docEl);
 			});
 
 			// Do this some time later to prevent extra mutations


### PR DESCRIPTION
We remove the `documentElement` in order to allow all of memory cleanup
to occur. However some libraries, like jQuery freak out when a document
doesn't have a documentElement.

The solution is to instead replace the documentElement with a new one.
This means there still is one, but the old one can have its memory
cleaned up.