### PR TITLE
Error when a timeout occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ Configuration options that are a [StealConfig](https://stealjs.com/docs/steal-to
 
 Specify a timeout in milliseconds for how long should be waited before returning whatever HTML has already been rendered. Defaults to **5000**.
 
+###### Debugging Timeouts
+
+A timeout might occur for a variety of reasons such as:
+
+* __Running in development__: In development the server has to load all modules the first time a request is made. In this case the first render could timeout. You can specify a longer timeout to remedy this.
+* __Unresolved promise__: If you have a promise that never resolves it could cause a timeout. Be sure to always resolve your promises and catch rejections.
+* __Undetectable recursion__: can-zone tracks all types of asynchronous tasks. Some times it can't detect that a program will never complete. One example is `setTimeout` call that is called recursively. Use [Zone.ignore](https://github.com/canjs/can-zone/tree/master/docs) to ignore those type of code.
+
+If all else fails, use the [debug](#debug--false) option to get more information on why the timeout occurs.
+
 ##### debug : false
 
 Specify to turn on debug mode when used in conjunction with timeout. If rendering times out debugging information will be attached to a modal window in the document. For this reason you only want to use the debug option during development.

--- a/lib/ssr-stream.js
+++ b/lib/ssr-stream.js
@@ -47,7 +47,8 @@ SafeStream.prototype.render = function(){
 
 	zones.push(cookies(request, response));
 
-	var timeoutZone = timeout(this.options.timeout);
+	var timeoutMs = this.options.timeout;
+	var timeoutZone = timeout(timeoutMs);
 	zones.push(timeoutZone);
 
 	if(this.options.debug) {
@@ -108,6 +109,7 @@ SafeStream.prototype.render = function(){
 			if(!(err instanceof TimeoutError)) {
 				throw err;
 			}
+			console.error("A timeout of", timeoutMs + "ms", "was exceeded. See https://github.com/donejs/done-ssr#timeout--5000 for more information on timeouts.");
 			return zone.data;
 		}).then(function(data){
 			var html = doctype + "\n" + data.html;

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -7,6 +7,7 @@ Object.assign(exports, require("./incremental"));
 Object.assign(exports, require("./request"));
 Object.assign(exports, require("./server"));
 Object.assign(exports, require("./ua"));
+Object.assign(exports, require("./logging"));
 
 exports.removeMutationObserverZone = function(data) {
 	return {

--- a/test/helpers/logging.js
+++ b/test/helpers/logging.js
@@ -1,0 +1,61 @@
+function makeExpectation(type) {
+	var original;
+	var expectedResults = [];
+
+	function stubbed() {
+		var message = Array.from(arguments).map(function(token) {
+			// Case for error objects. If you send an error to the console,
+			//  its "toString" gives you "Error: " plus the message, which
+			//  is undesirable for trying to check its content against a known
+			//  string
+			if(typeof(token) !== "string" && token.message) {
+				return token.message;
+			} else {
+				return token;
+			}
+		}).join(" ");
+
+		expectedResults.forEach(function(expected) {
+			var matched = typeof expected.source === "string" ?
+				message === expected.source :
+				expected.source.test(message);
+
+			if(matched) {
+				expected.count++;
+			}
+			if(typeof expected.fn === "function") {
+				expected.fn.call(null, message, matched);
+			}
+		});
+	}
+
+	return function(expected, fn) {
+		var matchData = {
+			source: expected,
+			fn: fn,
+			count: 0
+		};
+		expectedResults.push(matchData);
+
+		if(!original) {
+			original = console[type];
+			console[type] = stubbed;
+		}
+
+		// Simple teardown
+		return function() {
+			expectedResults.splice(expectedResults.indexOf(matchData), 1);
+			if(original && expectedResults.length < 1) {
+				// restore when all teardown functions have been called.
+				console[type] = original;
+				original = null;
+			}
+			return matchData.count;
+		};
+	};
+}
+
+module.exports = {
+	willWarn: makeExpectation("warn"),
+	willError: makeExpectation("error")
+};


### PR DESCRIPTION
This adds an error message for when a timeout occurs and links to more
detailed documentation. This should help the case where the first render
does not show anything.