### PR TITLE
Error when a timeout occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,23 @@ Configuration options that are a [StealConfig](https://stealjs.com/docs/steal-to
 
 ##### timeout : 5000
 
-Specify a timeout in milliseconds for how long should be waited before returning whatever HTML has already been rendered. Defaults to **5000**
+Specify a timeout in milliseconds for how long should be waited before returning whatever HTML has already been rendered. Defaults to **5000**.
+
+###### Debugging Timeouts
+
+A timeout might occur for a variety of reasons such as:
+
+* __Running in development__: In development the server has to load all modules the first time a request is made. In this case the first render could timeout. You can specify a longer timeout to remedy this.
+* __Unresolved promise__: If you have a promise that never resolves it could cause a timeout. Be sure to always resolve your promises and catch rejections.
+* __Undetectable recursion__: can-zone tracks all types of asynchronous tasks. Some times it can't detect that a program will never complete. One example is `setTimeout` call that is called recursively. Use [Zone.ignore](https://github.com/canjs/can-zone/tree/master/docs) to ignore those type of code.
+
+If all else fails, use the [debug](#debug--false) option to get more information on why the timeout occurs.
+
+##### debug : false
+
+Specify to turn on debug mode when used in conjunction with timeout. If rendering times out debugging information will be attached to a modal window in the document. For this reason you only want to use the debug option during development.
+
+![debug output](https://cloud.githubusercontent.com/assets/361671/14474862/08b5f01e-00cd-11e6-8d70-b3f3ba835493.png)
 
 ##### auth: {cookie, domains}
 

--- a/lib/ssr-stream.js
+++ b/lib/ssr-stream.js
@@ -45,7 +45,8 @@ SafeStream.prototype.render = function(){
 		cookies(request, response)
 	];
 
-	var timeoutZone = timeout(this.options.timeout);
+	var timeoutMs = this.options.timeout;
+	var timeoutZone = timeout(timeoutMs);
 	zones.push(timeoutZone);
 
 	if(this.options.debug) {
@@ -92,6 +93,7 @@ SafeStream.prototype.render = function(){
 			if(!(err instanceof TimeoutError)) {
 				throw err;
 			}
+			console.error("A timeout of", timeoutMs + "ms", "was exceeded. See https://github.com/donejs/done-ssr#timeout--5000 for more information on timeouts.");
 			return zone.data;
 		}).then(function(data){
 			var html = doctype + "\n" + data.html;

--- a/test/logging.js
+++ b/test/logging.js
@@ -1,0 +1,61 @@
+function makeExpectation(type) {
+	var original;
+	var expectedResults = [];
+
+	function stubbed() {
+		var message = Array.from(arguments).map(function(token) {
+			// Case for error objects. If you send an error to the console,
+			//  its "toString" gives you "Error: " plus the message, which
+			//  is undesirable for trying to check its content against a known
+			//  string
+			if(typeof(token) !== "string" && token.message) {
+				return token.message;
+			} else {
+				return token;
+			}
+		}).join(" ");
+
+		expectedResults.forEach(function(expected) {
+			var matched = typeof expected.source === "string" ?
+				message === expected.source :
+				expected.source.test(message);
+
+			if(matched) {
+				expected.count++;
+			}
+			if(typeof expected.fn === "function") {
+				expected.fn.call(null, message, matched);
+			}
+		});
+	}
+
+	return function(expected, fn) {
+		var matchData = {
+			source: expected,
+			fn: fn,
+			count: 0
+		};
+		expectedResults.push(matchData);
+
+		if(!original) {
+			original = console[type];
+			console[type] = stubbed;
+		}
+
+		// Simple teardown
+		return function() {
+			expectedResults.splice(expectedResults.indexOf(matchData), 1);
+			if(original && expectedResults.length < 1) {
+				// restore when all teardown functions have been called.
+				console[type] = original;
+				original = null;
+			}
+			return matchData.count;
+		};
+	};
+}
+
+module.exports = {
+	willWarn: makeExpectation("warn"),
+	willError: makeExpectation("error")
+};

--- a/test/timeout_test.js
+++ b/test/timeout_test.js
@@ -68,4 +68,16 @@ describe("Timeouts", function(){
 			done();
 		}));
 	});
+
+	// Cannot do this in 2.x.
+	it.skip("Adds an error message when the timeout exceeds", function(done){
+		this.render("/slow").pipe(through(function(){
+			var count = undo();
+			Promise.resolve()
+			.then(function(){
+				assert.equal(count, 1, "Added error message about the timeout");
+			})
+			.then(done, done);
+		}));
+	});
 });


### PR DESCRIPTION
This adds an error message for when a timeout occurs and links to more
detailed documentation. This should help the case where the first render
does not show anything.