### PR TITLE
Use a Buffer for the mutations stream

### DIFF
--- a/zones/mutations.js
+++ b/zones/mutations.js
@@ -16,7 +16,8 @@ module.exports = function(){
 
 		function onMutations(records) {
 			var bytes = encoder.encode(records);
-			mutationStream.push(bytes);
+			var buffer = Buffer.from(bytes);
+			mutationStream.push(buffer);
 		}
 
 		function startListeningToMutations() {


### PR DESCRIPTION
Node 6 doesn't support streams being pushed a Typed Array. Instead it
expects a Buffer (which is also a typed array).