### PR TITLE
Don't add a preload link for Safari

### DIFF
--- a/lib/util/supports_preloadfetch.js
+++ b/lib/util/supports_preloadfetch.js
@@ -1,6 +1,7 @@
 var useragent = require("useragent");
 
-module.exports = function(headers = {}) {
+module.exports = function(request = {}) {
+	var headers = request.headers || request;
 	var uaString = headers["user-agent"] || "";
 	var browser = useragent.is(uaString);
 

--- a/lib/util/supports_preloadfetch.js
+++ b/lib/util/supports_preloadfetch.js
@@ -1,0 +1,8 @@
+var useragent = require("useragent");
+
+module.exports = function(headers = {}) {
+	var uaString = headers["user-agent"] || "";
+	var browser = useragent.is(uaString);
+
+	return !browser.safari;
+};

--- a/zones/push-mutations/reattach.js
+++ b/zones/push-mutations/reattach.js
@@ -1,16 +1,19 @@
 var fs = require("fs");
 var path = require("path");
 var cloneUtils = require("ir-clone");
+var supportsPreloadFetch = require("../../lib/util/supports_preloadfetch");
 
 var clientScript = getClientScript();
 
 module.exports = function(url){
 	return function(data){
 		function injectStuff() {
+			var usePreload = !data.pushAllowed && supportsPreloadFetch(data.request);
+
 			cloneUtils.injectFrame(data.document, {
 				reattachScript: clientScript,
 				streamUrl: url,
-				preload: !data.pushAllowed
+				preload: usePreload
 			});
 		}
 


### PR DESCRIPTION
Safari supports Preload links but not for `fetch`. Adding one causes the
data to be consumed but not used, messing up mutation reattachment.