### PR TITLE
Add can-view-nodelist to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "can-namespace": "^1.0.0",
     "can-reflect": "^1.11.0",
     "can-vdom": "^4.4.0",
+    "can-view-nodelist": "^4.0.0",
     "can-zone": "^1.0.0",
     "dom-patch": "^2.1.1",
     "done-mutation": "^3.0.0",


### PR DESCRIPTION
It’s used on [this line](https://github.com/donejs/done-ssr/blob/2cdc7213c0fc5f17752132363df3c2f2dd5436f1/zones/canjs/cleanup.js#L1) but wasn’t in package.json